### PR TITLE
В формі співробітника додано фільтр на відображення вакансій тільки з вибраного відділу

### DIFF
--- a/l10n_ua_hr_base/models/hr_employee.py
+++ b/l10n_ua_hr_base/models/hr_employee.py
@@ -214,3 +214,30 @@ class HrEmployee(models.Model):
 	'unique(rnokpp, company_id)',
         'RNOKPP (IPN) must be unique!',
     )
+
+    # === Staffing Table / Job filtering ===
+    allowed_job_ids = fields.Many2many(
+        'hr.job', 
+        compute='_compute_allowed_job_ids',
+        string='Allowed Jobs (by Staffing Table)'
+    )
+
+    @api.depends('department_id')
+    def _compute_allowed_job_ids(self):
+        for employee in self:
+            if employee.department_id:
+                # Find approved staffing records for the selected department
+                staffing_records = self.env['hr.staffing.table'].search([
+                    ('department_id', '=', employee.department_id.id),
+                    ('state', '=', 'approved') 
+                ])
+                employee.allowed_job_ids = staffing_records.mapped('job_id')
+            else:
+                # If no department is selected, allow all jobs
+                employee.allowed_job_ids = self.env['hr.job'].search([])
+
+    @api.onchange('department_id')
+    def _onchange_department_clear_job(self):
+        """Clears the job position field if it does not belong to the newly selected department"""
+        if self.job_id and self.job_id not in self.allowed_job_ids:
+            self.job_id = False

--- a/l10n_ua_hr_base/views/hr_employee_views.xml
+++ b/l10n_ua_hr_base/views/hr_employee_views.xml
@@ -6,6 +6,15 @@
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="arch" type="xml">
+
+	    <xpath expr="//field[@name='job_id']" position="before">
+                <field name="allowed_job_ids" invisible="1"/>
+            </xpath>
+
+            <xpath expr="//field[@name='job_id']" position="attributes">
+                <attribute name="domain">[('id', 'in', allowed_job_ids)]</attribute>
+	    </xpath>
+
             <!-- Hide duplicate citizenship fields from core Personal page -->
             <!-- We use Documents tab instead with more Ukrainian-specific fields -->
             <xpath expr="//group[@name='citizenship']" position="attributes">


### PR DESCRIPTION
Логіка роботи:

1. HR-менеджер відкриває картку співробітника і обирає Відділ (наприклад, "Бухгалтерія").
2. Функція _compute_allowed_job_ids миттєво робить пошук по моделі hr.staffing.table і знаходить всі затверджені штатні одиниці, які належать до "Бухгалтерії". 
3. Поле allowed_job_ids заповнюється ID цих посад (наприклад, "Головний бухгалтер", "Бухгалтер"). 
4. Завдяки XML-атрибуту domain="[('id', 'in', allowed_job_ids)]", у випадаючому списку поля Посада (job_id) з'являться лише ті посади, які є в списку allowed_job_ids. 
5. Якщо після вибору посади змінити відділ на "IT", метод _onchange_department_clear_job побачить, що посада "Бухгалтер" не підходить для відділу "IT", і автоматично очистить поле, запобігаючи помилкам в даних.