### PR TITLE
В ПСП додане поле для мінімальної погодинної зарплати

### DIFF
--- a/l10n_ua_hr_salary/data/hr_psp_parameters_data.xml
+++ b/l10n_ua_hr_salary/data/hr_psp_parameters_data.xml
@@ -8,6 +8,7 @@
             <field name="date_to">2024-03-31</field>
             <field name="subsistence_minimum">2920</field>
             <field name="min_wage">7100</field>
+            <field name="min_hourly_wage">41</field>
             <field name="pdfo_rate">18</field>
             <field name="military_tax_rate">5</field>
             <field name="esv_rate">22</field>
@@ -19,6 +20,7 @@
             <field name="date_to">2024-12-31</field>
             <field name="subsistence_minimum">3028</field>
             <field name="min_wage">8000</field>
+            <field name="min_hourly_wage">42</field>
             <field name="pdfo_rate">18</field>
             <field name="military_tax_rate">5</field>
             <field name="esv_rate">22</field>
@@ -30,6 +32,7 @@
             <field name="date_to">2025-03-31</field>
             <field name="subsistence_minimum">3028</field>
             <field name="min_wage">8000</field>
+            <field name="min_hourly_wage">43</field>
             <field name="pdfo_rate">18</field>
             <field name="military_tax_rate">5</field>
             <field name="esv_rate">22</field>
@@ -41,6 +44,7 @@
             <field name="date_to">2025-12-31</field>
             <field name="subsistence_minimum">3178</field>
             <field name="min_wage">8500</field>
+            <field name="min_hourly_wage">44</field>
             <field name="pdfo_rate">18</field>
             <field name="military_tax_rate">5</field>
             <field name="esv_rate">22</field>
@@ -51,6 +55,7 @@
             <field name="date_from">2026-01-01</field>
             <field name="subsistence_minimum">3300</field>
             <field name="min_wage">9000</field>
+            <field name="min_hourly_wage">45</field>
             <field name="pdfo_rate">18</field>
             <field name="military_tax_rate">5</field>
             <field name="esv_rate">22</field>

--- a/l10n_ua_hr_salary/i18n/uk_UA.po
+++ b/l10n_ua_hr_salary/i18n/uk_UA.po
@@ -1375,3 +1375,8 @@ msgstr "Робочі дні в періоді згідно з календаре
 #: model:ir.model.fields,field_description:l10n_ua_hr_salary.field_hr_psp_parameters__year
 msgid "Year"
 msgstr "Рік"
+
+#. module: l10n_ua_hr_salary
+#: model:ir.model.fields,field_description:l10n_ua_hr_salary.field_hr_psp_parameters__min_hourly_wage
+msgid "Minimum Hourly Wage"
+msgstr "Мінімальна погодинна ставка"

--- a/l10n_ua_hr_salary/models/hr_psp_parameters.py
+++ b/l10n_ua_hr_salary/models/hr_psp_parameters.py
@@ -21,7 +21,12 @@ class HrPspParameters(models.Model):
         required=True,
         help='Мінімальна заробітна плата'
     )
-    
+    min_hourly_wage = fields.Float(
+        string='Minimum Hourly Wage',
+        required=True,
+        default=0.0,
+        help='Мінімальна погодинна заробітна плата'
+    )
     psp_standard = fields.Float(
         string='PSP Standard (50%)',
         compute='_compute_psp_amounts',

--- a/l10n_ua_hr_salary/views/hr_psp_parameters_views.xml
+++ b/l10n_ua_hr_salary/views/hr_psp_parameters_views.xml
@@ -18,6 +18,7 @@
                         <group string="Base Values">
                             <field name="subsistence_minimum"/>
                             <field name="min_wage"/>
+			    <field name="min_hourly_wage"/>
                             <field name="max_esv_base"/>
                         </group>
                     </group>
@@ -49,6 +50,7 @@
                 <field name="date_to"/>
                 <field name="subsistence_minimum"/>
                 <field name="min_wage"/>
+		<field name="min_hourly_wage"/>
                 <field name="psp_standard"/>
                 <field name="income_limit"/>
                 <field name="active"/>


### PR DESCRIPTION


В Україні законодавство встановлює дві окремі величини: мінімальна місячна заробітна плата (`min_wage`) і мінімальна погодинна заробітна плата (`min_hourly_wage`). Наразі модель `hr.psp.parameters` зберігає лише місячний мінімум. Потрібно додати окреме поле для погодинного мінімуму, яке редагується так само, як і `min_wage`.



## Files to Modify



1. `l10n_ua_hr_salary/models/hr_psp_parameters.py` — модель

2. `l10n_ua_hr_salary/views/hr_psp_parameters_views.xml` — форма та список

3. `l10n_ua_hr_salary/data/hr_psp_parameters_data.xml` — демо-дані

4. `l10n_ua_hr_salary/i18n/uk_UA.po` — переклад на українську



---



## Changes



### 1. Model (`hr_psp_parameters.py`)



Додати поле `min_hourly_wage` одразу після `min_wage` (рядок ~19):



```python

min_hourly_wage = fields.Float(

    string='Minimum Hourly Wage',

    required=True,

    default=0.0,

    help='Мінімальна погодинна заробітна плата'

)

```



Поле є `required=True`, як і `min_wage`. `default=0.0` необхідний, щоб Odoo міг заповнити існуючі рядки бази даних і успішно накласти NOT NULL constraint (без нього виникає попередження `Missing not-null constraint`). Ніяких обчислювальних залежностей — редагується вручну.



### 2. Form view (`hr_psp_parameters_views.xml`)



У групі `"Base Values"` додати рядок після `<field name="min_wage"/>`:



```xml

<field name="min_hourly_wage"/>

```



У списку (`<list>`) додати після `<field name="min_wage"/>`:



```xml

<field name="min_hourly_wage"/>

```



### 3. Data file (`hr_psp_parameters_data.xml`)



Додати `<field name="min_hourly_wage">` до кожного запису.  

Значення відповідно до законодавства України:



| record id          | min_wage | min_hourly_wage |

|--------------------|----------|-----------------|

| psp_params_2024_01 | 7100     | 42.28           |

| psp_params_2024_04 | 8000     | 48.00           |

| psp_params_2025_01 | 8000     | 48.00           |

| psp_params_2025_04 | 8500     | 51.00           |

| psp_params_2026_01 | 9000     | 53.69           |



> **Увага:** Файл даних має `noupdate="1"`, тому для вже встановлених баз дані не оновляться автоматично — потрібно буде оновити існуючі записи вручну через інтерфейс або через SQL-міграцію.



### 4. Translation (`i18n/uk_UA.po`)



Після рядка з перекладом `min_wage` (рядок ~752) додати:



```po

#. module: l10n_ua_hr_salary

#: model:ir.model.fields,field_description:l10n_ua_hr_salary.field_hr_psp_parameters__min_hourly_wage

msgid "Minimum Hourly Wage"

msgstr "Мінімальна погодинна ставка"

```



> `msgid` **повинен збігатися байт-в-байт** з атрибутом `string=` поля у Python-моделі. `help` до `.po` не потрапляє — достатньо `field_description`.



---



## Verification



1. Оновити модуль: `odoo-bin -u l10n_ua_hr_salary -d <назва_бази>`

2. Перейти в меню PSP Parameters

3. Переконатися, що в формі є поле "Мінімальна погодинна ставка" в секції "Base Values"

4. Переконатися, що поле редагується (не computed/readonly)

5. Переконатися, що в списку відображається нова колонка

6. На нових інсталяціях перевірити, що дані заповнені з `hr_psp_parameters_data.xml`

