### PR TITLE
Автоматичне оновлення kp_code та kp_name при зміні kp_id в Вакансії та в формі співробітника

### DIFF
--- a/l10n_ua_hr_base/models/hr_employee.py
+++ b/l10n_ua_hr_base/models/hr_employee.py
@@ -135,10 +135,10 @@ class HrEmployee(models.Model):
 
     # === Related fields from hr.job (readonly) ===
     job_kp_code = fields.Char(
-        string='KP Code', related='job_id.kp_code', readonly=True, store=False,
+        string='KP Code', compute='_compute_job_kp_fields', readonly=True, store=True,
         help='Код професії за Класифікатором професій ДК 003:2010')
     job_kp_name = fields.Char(
-        string='KP Name', related='job_id.kp_name', readonly=True, store=False,
+        string='KP Name', compute='_compute_job_kp_fields', readonly=True, store=True,
         help='Назва професії за Класифікатором професій')
     job_work_conditions = fields.Selection(
         related='job_id.work_conditions', readonly=True, store=False,
@@ -155,6 +155,12 @@ class HrEmployee(models.Model):
     job_max_salary = fields.Monetary(
         related='job_id.max_salary', readonly=True, store=False,
         currency_field='job_currency_id', string='Max Salary')
+
+    @api.depends('job_id', 'job_id.kp_code', 'job_id.kp_name')
+    def _compute_job_kp_fields(self):
+            for employee in self:
+                employee.job_kp_code = employee.job_id.kp_code if employee.job_id else False
+                employee.job_kp_name = employee.job_id.kp_name if employee.job_id else False
 
     @api.depends('children_ids')
     def _compute_children_count(self):

--- a/l10n_ua_hr_base/models/hr_job.py
+++ b/l10n_ua_hr_base/models/hr_job.py
@@ -6,9 +6,11 @@ class HrJob(models.Model):
 
     kp_code = fields.Char(
         string='KP Code', size=10,
+        compute='_compute_kp_fields', store=True,
         help='Code from Classifier of Professions (KP 2010)')
     kp_name = fields.Char(
         string='KP Name',
+        compute='_compute_kp_fields', store=True,
         help='Name according to Classifier of Professions')
     kp_id = fields.Many2one(
         'hr.kp2010', string='Profession (KP)',
@@ -41,6 +43,12 @@ class HrJob(models.Model):
     probation_days = fields.Integer(
         string='Probation Period (days)',
         help='Default probation period in days')
+
+    @api.depends('kp_id')
+    def _compute_kp_fields(self):
+        for job in self:
+            job.kp_code = job.kp_id.code if job.kp_id else False
+            job.kp_name = job.kp_id.name if job.kp_id else False
 
     @api.onchange('kp_id')
     def _onchange_kp_id(self):


### PR DESCRIPTION
**Загальна інформація**
`hr_job`: `kp_code` та `kp_name` перетворено з` plain Char` на` compute='_compute_kp_fields', store=True `з `@api.depends('kp_id')`. Виправляє проблему зникнення значень після збереження — readonly поля не відправляються клієнтом на сервер при save, тому onchange-значення губилися.

`hr_employee`: `job_kp_code` та `job_kp_name` перетворено з `related='job_id.kp_code'`, `store=False` на `compute='_compute_job_kp_fields', store=True `з `@api.depends('job_id', 'job_id.kp_code', 'job_id.kp_name')`. Тепер ORM автоматично оновлює значення у всіх співробітників при зміні класифікатора у посаді.

**План тестування**
 Оновити модуль `l10n_ua_hr_base`
 HR → Конфігурація → Посади → відкрити посаду → вкладка "Україна" → вибрати kp_id → зберегти → переконатись, що kp_code і kp_name збереглись
 HR → Співробітники → відкрити співробітника з налаштованою посадою → вкладка "UA: Робота" → поля "Код КП" і "Назва КП" мають відображати значення з посади
 Змінити kp_id у посаді → зберегти → перевірити форму співробітника → значення оновились автоматично