### PR TITLE
Переклад звітів Average Headcount та Wage Fund Report

### DIFF
--- a/l10n_ua_hr_reports/i18n/uk_UA.po
+++ b/l10n_ua_hr_reports/i18n/uk_UA.po
@@ -17,6 +17,7 @@ msgstr ""
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5_line__category__1
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__employee_id
 msgid "1 - Employee"
 msgstr "1 - Працівник"
 
@@ -85,53 +86,74 @@ msgstr "Нараховано та виплачено"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__message_needaction
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__message_needaction
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__message_needaction
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__message_needaction
+
 msgid "Action Needed"
 msgstr "Потрібна дія"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__activity_ids
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__activity_ids
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__activity_ids
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_ids
+
 msgid "Activities"
 msgstr "Активності"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__activity_exception_decoration
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__activity_exception_decoration
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__activity_exception_decoration
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_exception_decoration
 msgid "Activity Exception Decoration"
 msgstr "Оформлення виключення активності"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__activity_state
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__activity_state
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__activity_state
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_state
 msgid "Activity State"
 msgstr "Стан активності"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__activity_type_icon
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__activity_type_icon
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__activity_type_icon
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_type_icon
 msgid "Activity Type Icon"
 msgstr "Іконка типу активності"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__4
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__4
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__4
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__4
+
 msgid "April"
 msgstr "Квітень"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__message_attachment_count
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__message_attachment_count
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__message_attachment_count
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__message_attachment_count
 msgid "Attachment Count"
 msgstr "Кількість вкладень"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__8
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__8
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__8
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__8
 msgid "August"
 msgstr "Серпень"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__report_type__headcount
+#: model:ir.ui.menu,name:l10n_ua_hr_reports.menu_hr_report_headcount
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_headcount_view_search
 msgid "Average Headcount"
 msgstr "Середньооблікова чисельність"
 
@@ -149,6 +171,8 @@ msgstr "Категорія"
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__company_id
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__company_id
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wizard__company_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__company_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__company_id
 msgid "Company"
 msgstr "Компанія"
 
@@ -168,6 +192,11 @@ msgstr "Створити місячний звіт ЄСВ Д5"
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__create_uid
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5_line__create_uid
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wizard__create_uid
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__create_uid
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__create_uid
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__create_uid
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_accrual__create_uid
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__create_uid
 msgid "Created by"
 msgstr "Створив"
 
@@ -177,6 +206,11 @@ msgstr "Створив"
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__create_date
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5_line__create_date
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wizard__create_date
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__create_date
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__create_date
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__create_date
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_accrual__create_date
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__create_date
 msgid "Created on"
 msgstr "Створено"
 
@@ -230,6 +264,8 @@ msgstr "Дата по"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__12
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__12
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__12
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__12
 msgid "December"
 msgstr "Грудень"
 
@@ -239,12 +275,19 @@ msgstr "Грудень"
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__display_name
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5_line__display_name
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wizard__display_name
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__display_name
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__display_name
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__display_name
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_accrual__display_name
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__display_name
 msgid "Display Name"
 msgstr "Відображувана назва"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_1df__state__draft
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__state__draft
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__state__draft
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__state__draft
 msgid "Draft"
 msgstr "Чернетка"
 
@@ -282,6 +325,9 @@ msgstr "Експорт XML"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__2
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__2
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__2
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__2
+
 msgid "February"
 msgstr "Лютий"
 
@@ -293,18 +339,24 @@ msgstr "Ім'я"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__message_follower_ids
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__message_follower_ids
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__message_follower_ids
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__message_follower_ids
 msgid "Followers"
 msgstr "Підписники"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__message_partner_ids
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__message_partner_ids
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__message_partner_ids
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__message_partner_ids
 msgid "Followers (Partners)"
 msgstr "Підписники (Партнери)"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_1df__activity_type_icon
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_d5__activity_type_icon
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__activity_type_icon
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_type_icon
 msgid "Font awesome icon e.g. fa-tasks"
 msgstr "Іконка Font Awesome, напр. fa-tasks"
 
@@ -312,6 +364,8 @@ msgstr "Іконка Font Awesome, напр. fa-tasks"
 #: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_1df_view_form
 #: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_d5_view_form
 #: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wizard_view_form
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_headcount_view_form
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
 msgid "Generate"
 msgstr "Згенерувати"
 
@@ -325,6 +379,8 @@ msgstr "Згенерувати звіт"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_1df__state__generated
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__state__generated
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__state__generated
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__state__generated
 msgid "Generated"
 msgstr "Згенеровано"
 
@@ -336,6 +392,8 @@ msgstr "Майстер звітів HR"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__has_message
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__has_message
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__has_message
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__has_message
 msgid "Has Message"
 msgstr "Є повідомлення"
 
@@ -350,24 +408,35 @@ msgstr "Дата прийняття"
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__id
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5_line__id
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wizard__id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_accrual__id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__id
 msgid "ID"
 msgstr "ID"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__activity_exception_icon
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__activity_exception_icon
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__activity_exception_icon
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_exception_icon
 msgid "Icon"
 msgstr "Іконка"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_1df__activity_exception_icon
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_d5__activity_exception_icon
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__activity_exception_icon
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_exception_icon
 msgid "Icon to indicate an exception activity."
 msgstr "Іконка для позначення виключної активності."
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_1df__message_needaction
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_d5__message_needaction
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__message_needaction
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__message_needaction
 msgid "If checked, new messages require your attention."
 msgstr "Якщо позначено, нові повідомлення потребують вашої уваги."
 
@@ -376,6 +445,10 @@ msgstr "Якщо позначено, нові повідомлення потр�
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_1df__message_has_sms_error
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_d5__message_has_error
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_d5__message_has_sms_error
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__message_has_error
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__message_has_sms_error
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__message_has_error
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
 msgstr "Якщо позначено, деякі повідомлення мають помилку доставки."
 
@@ -397,24 +470,32 @@ msgstr "Код типу доходу для 1ДФ"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__message_is_follower
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__message_is_follower
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__message_is_follower
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__message_is_follower
 msgid "Is Follower"
 msgstr "Є підписником"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__1
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__1
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__1
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__1
 msgid "January"
 msgstr "Січень"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__7
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__7
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__7
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__7
 msgid "July"
 msgstr "Липень"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__6
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__6
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__6
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__6
 msgid "June"
 msgstr "Червень"
 
@@ -429,6 +510,11 @@ msgstr "Прізвище"
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__write_uid
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5_line__write_uid
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wizard__write_uid
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__write_uid
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__write_uid
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__write_uid
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_accrual__write_uid
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__write_uid
 msgid "Last Updated by"
 msgstr "Оновив"
 
@@ -438,12 +524,19 @@ msgstr "Оновив"
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__write_date
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5_line__write_date
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wizard__write_date
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__write_date
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__write_date
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__write_date
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_accrual__write_date
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__write_date
 msgid "Last Updated on"
 msgstr "Оновлено"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__3
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__3
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__3
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__3
 msgid "March"
 msgstr "Березень"
 
@@ -456,18 +549,24 @@ msgstr "Позначити як подано"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__5
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__5
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__5
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__5
 msgid "May"
 msgstr "Травень"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__message_has_error
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__message_has_error
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__message_has_error
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__message_has_error
 msgid "Message Delivery error"
 msgstr "Помилка доставки повідомлення"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__message_ids
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__message_ids
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__message_ids
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__message_ids
 msgid "Messages"
 msgstr "Повідомлення"
 
@@ -484,42 +583,56 @@ msgstr "Сума військового збору"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__month
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wizard__month
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__month
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__month
 msgid "Month"
 msgstr "Місяць"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__my_activity_date_deadline
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__my_activity_date_deadline
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__my_activity_date_deadline
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__my_activity_date_deadline
 msgid "My Activity Deadline"
 msgstr "Термін моєї активності"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__name
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__name
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__name
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__name
 msgid "Name"
 msgstr "Назва"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__activity_calendar_event_id
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__activity_calendar_event_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__activity_calendar_event_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_calendar_event_id
 msgid "Next Activity Calendar Event"
 msgstr "Подія календаря наступної активності"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__activity_date_deadline
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__activity_date_deadline
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__activity_date_deadline
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_date_deadline
 msgid "Next Activity Deadline"
 msgstr "Термін наступної активності"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__activity_summary
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__activity_summary
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__activity_summary
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_summary
 msgid "Next Activity Summary"
 msgstr "Опис наступної активності"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__activity_type_id
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__activity_type_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__activity_type_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_type_id
 msgid "Next Activity Type"
 msgstr "Тип наступної активності"
 
@@ -530,42 +643,60 @@ msgstr "Тип наступної активності"
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5_line__notes
 #: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_1df_view_form
 #: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_d5_view_form
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__notes
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__notes
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__notes
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__notes
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_headcount_view_form
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
 msgid "Notes"
 msgstr "Примітки"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__11
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__11
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__11
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__11
 msgid "November"
 msgstr "Листопад"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__message_needaction_counter
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__message_needaction_counter
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__message_needaction_counter
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__message_needaction_counter
 msgid "Number of Actions"
 msgstr "Кількість дій"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__message_has_error_counter
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__message_has_error_counter
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__message_has_error_counter
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__message_has_error_counter
 msgid "Number of errors"
 msgstr "Кількість помилок"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_1df__message_needaction_counter
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_d5__message_needaction_counter
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__message_needaction_counter
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__message_needaction_counter
 msgid "Number of messages requiring action"
 msgstr "Кількість повідомлень, що потребують дії"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_1df__message_has_error_counter
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_d5__message_has_error_counter
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__message_has_error_counter
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__message_has_error_counter
 msgid "Number of messages with delivery error"
 msgstr "Кількість повідомлень з помилкою доставки"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__10
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__10
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__10
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__10
 msgid "October"
 msgstr "Жовтень"
 
@@ -618,6 +749,9 @@ msgstr "РНОКПП"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df_line__report_id
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5_line__report_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__report_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_accrual__report_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__report_id
 msgid "Report"
 msgstr "Звіт"
 
@@ -640,24 +774,32 @@ msgstr "Тип звіту"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__activity_user_id
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__activity_user_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__activity_user_id
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_user_id
 msgid "Responsible User"
 msgstr "Відповідальний"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__message_has_sms_error
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__message_has_sms_error
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__message_has_sms_error
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__message_has_sms_error
 msgid "SMS Delivery error"
 msgstr "Помилка доставки SMS"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_d5__month__9
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__month__9
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_headcount__month__9
+#: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wage_fund__month__9
 msgid "September"
 msgstr "Вересень"
 
 #. module: l10n_ua_hr_reports
 #: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_1df_view_form
 #: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_d5_view_form
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_headcount_view_form
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
 msgid "Set to Draft"
 msgstr "Повернути в чернетку"
 
@@ -669,12 +811,16 @@ msgstr "Дата початку"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__state
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__state
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__state
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__state
 msgid "Status"
 msgstr "Статус"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_1df__activity_state
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_d5__activity_state
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__activity_state
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_state
 msgid ""
 "Status based on activities\n"
 "Overdue: Due date is already passed\n"
@@ -713,6 +859,8 @@ msgstr "Причина звільнення"
 #: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_1df_view_tree
 #: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_d5_view_form
 #: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_d5_view_tree
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_list
 msgid "Total"
 msgstr "Всього"
 
@@ -723,6 +871,7 @@ msgstr "Всього нараховано"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__total_esv
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__total_esv
 msgid "Total ESV"
 msgstr "Всього ЄСВ"
 
@@ -734,16 +883,19 @@ msgstr "Всього база ЄСВ"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__total_employees
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__total_employees
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__total_employees
 msgid "Total Employees"
 msgstr "Всього працівників"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__total_military
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__total_military
 msgid "Total Military Tax"
 msgstr "Всього військового збору"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__total_pdfo
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__total_pdfo
 msgid "Total PDFO"
 msgstr "Всього ПДФО"
 
@@ -755,23 +907,31 @@ msgstr "Всього виплачено"
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_1df__activity_exception_decoration
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_d5__activity_exception_decoration
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__activity_exception_decoration
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__activity_exception_decoration
 msgid "Type of the exception activity on record."
 msgstr "Тип виключної активності в записі."
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields.selection,name:l10n_ua_hr_reports.selection__hr_report_wizard__report_type__wage_fund
+#: model:ir.model,name:l10n_ua_hr_reports.model_hr_report_wage_fund
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
 msgid "Wage Fund Report"
 msgstr "Звіт про фонд оплати праці"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__website_message_ids
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__website_message_ids
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__website_message_ids
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__website_message_ids
 msgid "Website Messages"
 msgstr "Повідомлення веб-сайту"
 
 #. module: l10n_ua_hr_reports
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_1df__website_message_ids
 #: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_d5__website_message_ids
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__website_message_ids
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__website_message_ids
 msgid "Website communication history"
 msgstr "Історія комунікації веб-сайту"
 
@@ -789,5 +949,305 @@ msgstr "Відпрацьовано годин"
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_1df__year
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_d5__year
 #: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wizard__year
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__year
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__year
 msgid "Year"
 msgstr "Рік"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__accrual_summary_ids
+msgid "Accrual Summary"
+msgstr "Зведення нарахувань"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model,name:l10n_ua_hr_reports.model_hr_report_wage_fund_accrual
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_accrual__accrual_type_id
+msgid "Accrual Type"
+msgstr "Вид нарахування"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__fund_allowances
+msgid "Allowances Fund"
+msgstr "Фонд надбавок"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__fund_allowances
+msgid "Allowances and supplements"
+msgstr "Надбавки та доплати"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__avg_headcount_full
+msgid "Average Headcount (All)"
+msgstr "Середньооблікова чисельність (усього)"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__avg_headcount
+msgid "Average Headcount (Full-time)"
+msgstr "Середньооблікова чисельність (штатні)"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__avg_headcount
+msgid "Average headcount of full-time employees"
+msgstr "Середньооблікова чисельність штатних працівників"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__avg_headcount_full
+msgid "Average headcount including part-time (FTE equivalent)"
+msgstr "Середньооблікова чисельність з урахуванням часткової зайнятості"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model,name:l10n_ua_hr_reports.model_hr_report_headcount
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_headcount_view_form
+msgid "Average Headcount Report"
+msgstr "Звіт середньооблікової чисельності"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.actions.act_window,name:l10n_ua_hr_reports.action_hr_report_headcount
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_headcount_view_list
+msgid "Average Headcount Reports"
+msgstr "Звіти середньооблікової чисельності"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__fund_basic_salary
+msgid "Base salary accruals"
+msgstr "Нарахування основної заробітної плати"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__fund_basic_salary
+msgid "Basic Salary Fund"
+msgstr "Фонд основної зарплати"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__fund_bonuses
+msgid "Bonuses Fund"
+msgstr "Фонд премій"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__fund_bonuses
+msgid "Bonuses and premiums"
+msgstr "Премії та надбавки"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
+msgid "By Accrual Type"
+msgstr "За видами нарахувань"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
+msgid "By Employee"
+msgstr "По працівниках"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__total_calendar_days
+msgid "Calendar Days"
+msgstr "Календарних днів"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.actions.act_window,help:l10n_ua_hr_reports.action_hr_report_headcount
+msgid "Create an average headcount report"
+msgstr "Створити звіт середньооблікової чисельності"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.actions.act_window,help:l10n_ua_hr_reports.action_hr_report_wage_fund
+msgid "Create a wage fund report"
+msgstr "Створити звіт фонду оплати праці"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount__line_ids
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_headcount_view_form
+msgid "Daily Data"
+msgstr "Дані по днях"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__date
+msgid "Date"
+msgstr "Дата"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__day_of_week
+msgid "Day"
+msgstr "День тижня"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__department_id
+msgid "Department"
+msgstr "Підрозділ"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__line_ids
+msgid "Employee Details"
+msgstr "Деталі по працівниках"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__esv_amount
+msgid "ESV"
+msgstr "ЄСВ"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__fte_count
+msgid "FTE"
+msgstr "ФТЕ"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount_line__fte_count
+msgid "Full-time equivalent count"
+msgstr "Еквівалент повної зайнятості"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__gross_salary
+msgid "Gross Salary"
+msgstr "Нараховано (брутто)"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_headcount_line__headcount
+msgid "Headcount"
+msgstr "Чисельність"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model,name:l10n_ua_hr_reports.model_hr_report_headcount_line
+msgid "Headcount Report Daily Line"
+msgstr "Рядок звіту середньооблікової чисельності"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.constraint,message:l10n_ua_hr_reports.constraint_hr_report_headcount_unique_year_month_company_id
+msgid "Headcount report for this period already exists!"
+msgstr "Звіт середньооблікової чисельності за цей період вже існує!"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__military_amount
+msgid "Military Tax"
+msgstr "Військовий збір"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__total_military
+msgid "Military tax (5%)"
+msgstr "Військовий збір (5%)"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__net_salary
+msgid "Net Salary"
+msgstr "До виплати (нетто)"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount_line__headcount
+msgid "Number of full-time employees"
+msgstr "Кількість штатних працівників"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__total_employees
+msgid "Number of employees with payslips"
+msgstr "Кількість працівників з розрахунковими листками"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__fund_other
+msgid "Other accruals"
+msgstr "Інші нарахування"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__fund_other
+msgid "Other Payments"
+msgstr "Інші виплати"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_line__pdfo_amount
+msgid "PDFO"
+msgstr "ПДФО"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__total_pdfo
+msgid "Personal income tax (18%)"
+msgstr "Податок на доходи фізичних осіб (18%)"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_headcount_view_form
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
+msgid "Period"
+msgstr "Звітний період"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_headcount_view_form
+msgid "Results"
+msgstr "Результати"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
+msgid "Summary"
+msgstr "Загальні дані"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
+msgid "Tax Deductions"
+msgstr "Утримання"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.actions.act_window,help:l10n_ua_hr_reports.action_hr_report_headcount
+msgid "This report calculates the average number of employees for a given month according to Ukrainian methodology."
+msgstr "Звіт розраховує середньооблікову чисельність за місяць відповідно до методології Держстату України."
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.actions.act_window,help:l10n_ua_hr_reports.action_hr_report_wage_fund
+msgid "This report analyzes the wage fund structure by accrual types and provides tax deduction summaries."
+msgstr "Звіт аналізує структуру фонду оплати праці за видами нарахувань та надає зведення утримань."
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund_accrual__total_amount
+msgid "Total Amount"
+msgstr "Сума"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__total_gross
+msgid "Total accrued amount (gross salary)"
+msgstr "Загальна сума нарахувань (брутто)"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_headcount__total_calendar_days
+msgid "Total calendar days in the period"
+msgstr "Загальна кількість календарних днів у периоді"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__total_gross
+msgid "Total Gross"
+msgstr "Всього нараховано (брутто)"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,field_description:l10n_ua_hr_reports.field_hr_report_wage_fund__total_net
+msgid "Total Net"
+msgstr "Всього до виплати (нетто)"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__total_net
+msgid "Total net salary (after deductions)"
+msgstr "Загальна сума до виплати (після утримань)"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.fields,help:l10n_ua_hr_reports.field_hr_report_wage_fund__total_esv
+msgid "Unified social contribution (22%)"
+msgstr "Єдиний соціальний внесок (22%)"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_search
+msgid "Wage Fund"
+msgstr "Фонд оплати праці"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model,name:l10n_ua_hr_reports.model_hr_report_wage_fund_line
+msgid "Wage Fund Report Employee Line"
+msgstr "Рядок звіту ФОП (по працівнику)"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.actions.act_window,name:l10n_ua_hr_reports.action_hr_report_wage_fund
+#: model:ir.ui.menu,name:l10n_ua_hr_reports.menu_hr_report_wage_fund
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_list
+msgid "Wage Fund Reports"
+msgstr "Звіти фонду оплати праці"
+
+#. module: l10n_ua_hr_reports
+#: model:ir.model.constraint,message:l10n_ua_hr_reports.constraint_hr_report_wage_fund_unique_year_month_company_id
+msgid "Wage fund report for this period already exists!"
+msgstr "Звіт фонду оплати праці за цей період вже існує!"
+
+#. module: l10n_ua_hr_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_reports.hr_report_wage_fund_view_form
+msgid "Wage Fund Structure"
+msgstr "Структура фонду оплати праці"
+

--- a/l10n_ua_hr_reports/models/hr_report_wage_fund.py
+++ b/l10n_ua_hr_reports/models/hr_report_wage_fund.py
@@ -42,7 +42,7 @@ class HrReportWageFund(models.Model):
 
     # Summary totals
     total_employees = fields.Integer(
-        string='Employees',
+        string='Total Employees',
         help='Number of employees with payslips'
     )
     total_gross = fields.Monetary(


### PR DESCRIPTION
Зміни в  `l10n_ua_hr_reports/models/hr_report_wage_fund.py`:

**БУЛО**:
```
total_employees = fields.Integer(
    string='Employees',
    help='Number of employees with payslips'
)
```

**СТАЛО**:
```
total_employees = fields.Integer(
    string='Total Employees',
    help='Number of employees with payslips'
)
```

Навіщо: поля `total_employees` у моделях 1df і d5 вже мають `string='Total Employees',` тому переклад "Всього працівників" вже є в .po файлі. Однакова назва поля = один спільний запис у .po без дублікату.

Всі інші зміни,  - переклад в .po