### PR TITLE
Виправлений алгоритм розрахунку останньої дати місяця для звіту по фонду оплати праці

### DIFF
--- a/l10n_ua_hr_reports/models/hr_report_wage_fund.py
+++ b/l10n_ua_hr_reports/models/hr_report_wage_fund.py
@@ -151,7 +151,7 @@ class HrReportWageFund(models.Model):
         payslips = self.env['hr.payslip'].search([
             ('company_id', '=', self.company_id.id),
             ('date_from', '>=', date_from),
-            ('date_to', '<=',date_to),
+            ('date_to', '<', date_to),
             ('state', '=', 'done'),
         ])
 

--- a/l10n_ua_hr_reports/models/hr_report_wage_fund.py
+++ b/l10n_ua_hr_reports/models/hr_report_wage_fund.py
@@ -143,18 +143,15 @@ class HrReportWageFund(models.Model):
 
         # Calculate last day of month
         if month_int == 12:
-            date_to = fields.Date.from_string(f'{self.year}-12-31')
+            date_to = fields.Date.from_string(f'{self.year + 1}-01-01')
         else:
-            next_month = fields.Date.from_string(f'{self.year}-{month_int + 1:02d}-01')
-            date_to = next_month - fields.Date.from_string('1970-01-02') + fields.Date.from_string('1970-01-01')
-            # Simpler: just use day 28 as safe last day check
-            date_to = fields.Date.from_string(f'{self.year}-{month_int:02d}-28')
+            date_to = fields.Date.from_string(f'{self.year}-{month_int + 1:02d}-01')
 
         # Get payslips for the month
         payslips = self.env['hr.payslip'].search([
             ('company_id', '=', self.company_id.id),
             ('date_from', '>=', date_from),
-            ('date_to', '<=', f'{self.year}-{month_int:02d}-31'),
+            ('date_to', '<=',date_to),
             ('state', '=', 'done'),
         ])
 


### PR DESCRIPTION
## Контекст

При генерації звіту про фонд оплати праці за квітень 2026 року жодного рядка не додається, хоча розрахункові листи за 1–30 квітня існують і мають статус «Виконано». Причина — в методі `action_generate()`: пошук розрахункових листів використовує невалідний рядок дати `'2026-04-31'` (квітень має лише 30 днів), тому PostgreSQL повертає порожній результат. Додатково — мертвий код перезаписує правильно обчислену `date_to` значенням 28-го числа місяця, що ускладнює виявлення помилки.

## Критичний файл

`l10n_ua_hr_reports/models/hr_report_wage_fund.py` — метод `action_generate()`, рядки 141–159

## Що змінити

Замінити блок обчислення дат і пошуку розрахункових листів:

**Було (з помилками):**
```python
month_int = int(self.month)
date_from = fields.Date.from_string(f'{self.year}-{month_int:02d}-01')

if month_int == 12:
    date_to = fields.Date.from_string(f'{self.year}-12-31')
else:
    next_month = fields.Date.from_string(f'{self.year}-{month_int + 1:02d}-01')
    date_to = next_month - fields.Date.from_string('1970-01-02') + fields.Date.from_string('1970-01-01')
    # Simpler: just use day 28 as safe last day check
    date_to = fields.Date.from_string(f'{self.year}-{month_int:02d}-28')  # ПОМИЛКА: перезаписує

payslips = self.env['hr.payslip'].search([
    ('company_id', '=', self.company_id.id),
    ('date_from', '>=', date_from),
    ('date_to', '<=', f'{self.year}-{month_int:02d}-31'),  # ПОМИЛКА: невалідна дата для квітня, лютого тощо
    ('state', '=', 'done'),
])
```

**Стало (виправлено):**
```python
month_int = int(self.month)
date_from = fields.Date.from_string(f'{self.year}-{month_int:02d}-01')

if month_int == 12:
    next_month_start = fields.Date.from_string(f'{self.year + 1}-01-01')
else:
    next_month_start = fields.Date.from_string(f'{self.year}-{month_int + 1:02d}-01')

payslips = self.env['hr.payslip'].search([
    ('company_id', '=', self.company_id.id),
    ('date_from', '>=', date_from),
    ('date_to', '<', next_month_start),  # виключна верхня межа — завжди валідна дата
    ('state', '=', 'done'),
])
```

Цей підхід відповідає патерну, який вже використовується у `hr_report_d5.py` (щомісячний звіт ЄСВ Д5).

## Виявлені помилки

| № | Помилка | Наслідок |
|---|---------|----------|
| 1 | `'2026-04-31'` — невалідна дата для квітня | PostgreSQL повертає 0 рядків → порожній звіт |
| 2 | `date_to` перезаписується значенням 28-го числа і ніде не використовується | Приховано виключає дні 29–31 у довгих місяцях |

## Перевірка

1. Відкрити звіт про фонд оплати праці за квітень 2026 в інтерфейсі Odoo
2. Натиснути **Генерувати** — звіт має заповнитися всіма співробітниками, у яких є розрахунковий лист зі статусом «Виконано» за період 01.04.2026–30.04.2026
3. Перевірити лютий (28/29 днів) та грудень (31 день) для підтвердження коректності граничних випадків

