### PR TITLE
fix(#26): multi-company isolation — PR 3/3 (Salary: payslip, bonus, execution)

### DIFF
--- a/l10n_ua_hr_salary/models/hr_execution_document.py
+++ b/l10n_ua_hr_salary/models/hr_execution_document.py
@@ -82,6 +82,12 @@ class HrExecutionDocument(models.Model):
         default=lambda self: self.env.company
     )
 
+    @api.onchange('company_id')
+    def _onchange_company_id(self):
+        if self.employee_id and self.employee_id.company_id \
+                and self.employee_id.company_id != self.company_id:
+            self.employee_id = False
+
     @api.depends('total_amount')
     def _compute_collected_amount(self):
         for doc in self:

--- a/l10n_ua_hr_salary/models/hr_payslip.py
+++ b/l10n_ua_hr_salary/models/hr_payslip.py
@@ -285,6 +285,13 @@ class HrPayslip(models.Model):
             else:
                 payslip.version_id = False
 
+    @api.onchange('company_id')
+    def _onchange_company_id(self):
+        """Clear employee if from a different company (preserve shared employees)."""
+        if self.employee_id and self.employee_id.company_id \
+                and self.employee_id.company_id != self.company_id:
+            self.employee_id = False
+
     @api.depends('gross_salary', 'psp_type')
     def _compute_psp(self):
         for payslip in self:

--- a/l10n_ua_hr_salary/tests/__init__.py
+++ b/l10n_ua_hr_salary/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_psp_parameters
 from . import test_payslip
 from . import test_payslip_run
 from . import test_execution_document
+from . import test_execution_document_multi_company

--- a/l10n_ua_hr_salary/tests/test_execution_document_multi_company.py
+++ b/l10n_ua_hr_salary/tests/test_execution_document_multi_company.py
@@ -1,0 +1,40 @@
+"""Multi-company isolation для hr.execution.document (#26)."""
+
+from datetime import date
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestExecutionDocumentMultiCompany(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_a = cls.env.company
+        cls.company_b = cls.env['res.company'].create({'name': 'Company B'})
+        cls.employee_a = cls.env['hr.employee'].create({
+            'name': 'Emp A', 'company_id': cls.company_a.id,
+        })
+
+    def test_onchange_company_resets_cross_company_employee(self):
+        doc = self.env['hr.execution.document'].new({
+            'name': 'DOC-001',
+            'company_id': self.company_a.id,
+            'employee_id': self.employee_a.id,
+            'document_type': 'alimony',
+            'date_from': date(2026, 4, 1),
+        })
+        doc.company_id = self.company_b
+        doc._onchange_company_id()
+        self.assertFalse(doc.employee_id)
+
+    def test_onchange_company_keeps_same_company_employee(self):
+        doc = self.env['hr.execution.document'].new({
+            'name': 'DOC-002',
+            'company_id': self.company_a.id,
+            'employee_id': self.employee_a.id,
+            'document_type': 'alimony',
+            'date_from': date(2026, 4, 1),
+        })
+        doc._onchange_company_id()
+        self.assertEqual(doc.employee_id, self.employee_a)

--- a/l10n_ua_hr_salary/tests/test_payslip.py
+++ b/l10n_ua_hr_salary/tests/test_payslip.py
@@ -115,3 +115,38 @@ class TestPayslip(SalaryTestCase):
         payslip._compute_working_days()
         payslip._generate_accruals()
         self.assertTrue(payslip.accrual_ids)
+
+
+@tagged('post_install', '-at_install')
+class TestPayslipMultiCompany(SalaryTestCase):
+    """Multi-company isolation для hr.payslip."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_b = cls.env['res.company'].create({'name': 'Company B'})
+        cls.employee_b = cls.env['hr.employee'].create({
+            'name': 'Emp B', 'company_id': cls.company_b.id,
+        })
+
+    def test_onchange_company_resets_cross_company_employee(self):
+        payslip = self.env['hr.payslip'].new({
+            'company_id': self.company.id,
+            'employee_id': self.employee.id,
+            'date_from': date(2026, 4, 1),
+            'date_to': date(2026, 4, 30),
+        })
+        payslip.company_id = self.company_b
+        payslip._onchange_company_id()
+        self.assertFalse(payslip.employee_id)
+
+    def test_onchange_company_keeps_same_company_employee(self):
+        payslip = self.env['hr.payslip'].new({
+            'company_id': self.company.id,
+            'employee_id': self.employee.id,
+            'date_from': date(2026, 4, 1),
+            'date_to': date(2026, 4, 30),
+        })
+        # та сама компанія — нічого не скидається
+        payslip._onchange_company_id()
+        self.assertEqual(payslip.employee_id, self.employee)

--- a/l10n_ua_hr_salary/views/hr_execution_document_views.xml
+++ b/l10n_ua_hr_salary/views/hr_execution_document_views.xml
@@ -26,7 +26,8 @@
                     </div>
                     <group>
                         <group>
-                            <field name="employee_id"/>
+                            <field name="employee_id"
+                                   domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]"/>
                             <field name="document_type"/>
                             <field name="deduction_priority"/>
                         </group>

--- a/l10n_ua_hr_salary/views/hr_payslip_views.xml
+++ b/l10n_ua_hr_salary/views/hr_payslip_views.xml
@@ -30,7 +30,8 @@
                     </div>
                     <group>
                         <group>
-                            <field name="employee_id"/>
+                            <field name="employee_id"
+                                   domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]"/>
                             <field name="version_id"/>
                             <field name="department_id"/>
                             <field name="job_id"/>

--- a/l10n_ua_hr_salary_bonus/models/hr_bonus.py
+++ b/l10n_ua_hr_salary_bonus/models/hr_bonus.py
@@ -87,6 +87,12 @@ class HrBonus(models.Model):
                 vals['name'] = self.env['ir.sequence'].next_by_code('hr.bonus') or _('New')
         return super().create(vals_list)
 
+    @api.onchange('company_id')
+    def _onchange_company_id(self):
+        if self.employee_id and self.employee_id.company_id \
+                and self.employee_id.company_id != self.company_id:
+            self.employee_id = False
+
     def action_confirm(self):
         """Confirm the bonus - makes it ready for payroll inclusion."""
         for bonus in self:

--- a/l10n_ua_hr_salary_bonus/tests/__init__.py
+++ b/l10n_ua_hr_salary_bonus/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_bonus_multi_company

--- a/l10n_ua_hr_salary_bonus/tests/test_bonus_multi_company.py
+++ b/l10n_ua_hr_salary_bonus/tests/test_bonus_multi_company.py
@@ -1,0 +1,43 @@
+"""Multi-company isolation для hr.bonus (#26)."""
+
+from datetime import date
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestBonusMultiCompany(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_a = cls.env.company
+        cls.company_b = cls.env['res.company'].create({'name': 'Company B'})
+        cls.employee_a = cls.env['hr.employee'].create({
+            'name': 'Emp A', 'company_id': cls.company_a.id,
+            'bonus_system_enabled': True,
+        })
+        cls.bonus_type = cls.env['hr.bonus.type'].search([], limit=1) or \
+            cls.env['hr.bonus.type'].create({'name': 'Test', 'code': 'TEST'})
+
+    def test_onchange_company_resets_cross_company_employee(self):
+        bonus = self.env['hr.bonus'].new({
+            'company_id': self.company_a.id,
+            'employee_id': self.employee_a.id,
+            'bonus_type_id': self.bonus_type.id,
+            'date': date(2026, 4, 20),
+            'amount': 1000.0,
+        })
+        bonus.company_id = self.company_b
+        bonus._onchange_company_id()
+        self.assertFalse(bonus.employee_id)
+
+    def test_onchange_company_keeps_same_company_employee(self):
+        bonus = self.env['hr.bonus'].new({
+            'company_id': self.company_a.id,
+            'employee_id': self.employee_a.id,
+            'bonus_type_id': self.bonus_type.id,
+            'date': date(2026, 4, 20),
+            'amount': 500.0,
+        })
+        bonus._onchange_company_id()
+        self.assertEqual(bonus.employee_id, self.employee_a)

--- a/l10n_ua_hr_salary_bonus/views/hr_bonus_views.xml
+++ b/l10n_ua_hr_salary_bonus/views/hr_bonus_views.xml
@@ -22,7 +22,8 @@
                     </div>
                     <group>
                         <group>
-                            <field name="employee_id" readonly="state != 'draft'"/>
+                            <field name="employee_id" readonly="state != 'draft'"
+                                   domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]"/>
                             <field name="department_id"/>
                             <field name="bonus_type_id" readonly="state != 'draft'"/>
                         </group>


### PR DESCRIPTION
## Summary

PR 3 з 3 для Issue #26 — найвищий ризик (payroll documents).

Завершує серію мульти-компанійної ізоляції в HR. Разом з #27 (base) і #28 (documents) покриває всі 14 проблемних точок.

## Що змінено

### XML — domain з підтримкою shared records
- `l10n_ua_hr_salary/views/hr_payslip_views.xml` — `employee_id`
- `l10n_ua_hr_salary/views/hr_execution_document_views.xml` — `employee_id`
- `l10n_ua_hr_salary_bonus/views/hr_bonus_views.xml` — `employee_id`

### Models — smart onchange
- `hr.payslip._onchange_company_id`
- `hr.execution.document._onchange_company_id`
- `hr.bonus._onchange_company_id`

Всі скидають `employee_id` **тільки** при cross-company.

### Тести (6 нових)

- `TestPayslipMultiCompany` (2) — reset + keep
- `TestBonusMultiCompany` (2) — reset + keep
- `TestExecutionDocumentMultiCompany` (2) — reset + keep
- Створено нову директорію `tests/` для `l10n_ua_hr_salary_bonus` (модуль не мав тестів)

## Нотатка про shared employees

Odoo 19 enforce NOT NULL на `hr.employee.company_id` — кожен employee належить рівно одній компанії. Тому сценарій "shared employee" (протестований для department/job у PR #27) для payroll-моделей **не застосовується**. Замість нього — "same company → keep" перевірка.

Department/job далі підтримують shared (company_id=False) через base-level domain з PR #27 і #28.

Локально: **37/38 pass** (1 pre-existing `test_payslip_net_salary` fail, не від цього PR).

## Серія PR для #26

| PR | Шар | Файлів | Тестів |
|----|-----|--------|--------|
| [#27](https://github.com/NadozirnySvyatoslav/l10n_ua/pull/27) | HR Base | 8 | 5 |
| [#28](https://github.com/NadozirnySvyatoslav/l10n_ua/pull/28) | HR Documents | 6 | 4 |
| **#29 (цей)** | Salary | 11 | 6 |
| **Разом** | — | **25** | **15** |

## Test plan

- [x] Всі існуючі тести проходять (1 pre-existing fail не пов'язаний)
- [x] Нові multi-company тести на всі 3 моделі: cross-company reset + same-company keep
- [ ] Ручна перевірка multi-company у браузері:
  - [ ] Створити payslip у company A → переключити company → employee зникає
  - [ ] Створити bonus у company A → переключити company → employee зникає
  - [ ] Створити execution document у company A → переключити company → employee зникає

---
🤖 Разом з [Claude Code](https://claude.ai/claude-code)