### PR TITLE
feat(l10n_ua_hr_employee_transfer): переведення співробітника між компаніями (КЗпП ст. 36 п. 5)

### DIFF
--- a/l10n_ua_hr_employee_transfer/__init__.py
+++ b/l10n_ua_hr_employee_transfer/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/l10n_ua_hr_employee_transfer/__manifest__.py
+++ b/l10n_ua_hr_employee_transfer/__manifest__.py
@@ -1,0 +1,49 @@
+{
+    'name': 'Ukraine - HR Employee Transfer',
+    'version': '19.0.1.0.0',
+    'category': 'Human Resources/Localization',
+    'summary': 'Переведення співробітника в іншу організацію (КЗпП ст. 36 п. 5)',
+    'description': """
+Ukraine HR Employee Transfer
+============================
+
+Wizard для переведення співробітника з однієї компанії в іншу групи компаній
+за правилами КЗпП України (ст. 36 п. 5 — переведення на інше підприємство).
+
+Що робить:
+
+* Створює новий запис hr.employee у цільовій компанії з копіюванням
+  персональних даних (ІПН/RNOKPP, паспорт, адреса, військовий облік, освіта).
+* Опційно копіює банківські рахунки, особові документи, сімейні дані.
+* Створює наказ "Про припинення трудового договору (переведенням)" у source
+  та "Про прийняття на роботу (переведенням)" у target компаніях.
+* Деактивує source employee.
+* Підтримує режими балансу відпусток:
+  reset (за замовчуванням, згідно змін 2022 р.) / transfer (за згодою сторін).
+* Посилання cross-company через previous_employee_id / next_employee_id
+  (для відображення повної трудової історії).
+
+Залежить від:
+
+* hr
+* l10n_ua_hr_base — персональні дані, RNOKPP
+* l10n_ua_hr_documents — модель hr.order (накази)
+    """,
+    'author': 'Svyatoslav Nadozirny',
+    'website': 'https://many2one.online',
+    'license': 'LGPL-3',
+    'depends': [
+        'hr',
+        'mail',
+        'l10n_ua_hr_base',
+        'l10n_ua_hr_documents',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'wizard/hr_employee_transfer_wizard_views.xml',
+        'views/hr_employee_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/l10n_ua_hr_employee_transfer/models/__init__.py
+++ b/l10n_ua_hr_employee_transfer/models/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_employee

--- a/l10n_ua_hr_employee_transfer/models/hr_employee.py
+++ b/l10n_ua_hr_employee_transfer/models/hr_employee.py
@@ -1,0 +1,34 @@
+from odoo import models, fields
+
+
+class HrEmployee(models.Model):
+    _inherit = 'hr.employee'
+
+    previous_employee_id = fields.Many2one(
+        'hr.employee',
+        string='Попередній запис (переведення)',
+        check_company=False,
+        copy=False,
+        help='Запис співробітника в попередній компанії (створений через Transfer Wizard).',
+    )
+    next_employee_id = fields.Many2one(
+        'hr.employee',
+        string='Наступний запис (переведення)',
+        check_company=False,
+        copy=False,
+        help='Запис співробітника в цільовій компанії (створений через Transfer Wizard).',
+    )
+
+    def action_open_transfer_wizard(self):
+        self.ensure_one()
+        return {
+            'name': 'Переведення в іншу організацію',
+            'type': 'ir.actions.act_window',
+            'res_model': 'hr.employee.transfer.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {
+                'default_source_employee_id': self.id,
+                'default_source_company_id': self.company_id.id,
+            },
+        }

--- a/l10n_ua_hr_employee_transfer/security/ir.model.access.csv
+++ b/l10n_ua_hr_employee_transfer/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hr_employee_transfer_wizard_hr_manager,hr.employee.transfer.wizard hr_manager,model_hr_employee_transfer_wizard,hr.group_hr_manager,1,1,1,1

--- a/l10n_ua_hr_employee_transfer/tests/__init__.py
+++ b/l10n_ua_hr_employee_transfer/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_transfer_wizard

--- a/l10n_ua_hr_employee_transfer/tests/test_transfer_wizard.py
+++ b/l10n_ua_hr_employee_transfer/tests/test_transfer_wizard.py
@@ -1,0 +1,105 @@
+"""Tests for hr.employee.transfer.wizard — issue #32."""
+
+from datetime import date
+
+from odoo.tests import TransactionCase, tagged
+from odoo.exceptions import UserError
+
+
+@tagged('post_install', '-at_install')
+class TestEmployeeTransfer(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_a = cls.env.company
+        cls.company_b = cls.env['res.company'].create({'name': 'Transfer Target Co'})
+        cls.env.user.write({'company_ids': [(4, cls.company_b.id)]})
+
+        cls.dept_b = cls.env['hr.department'].create({
+            'name': 'Target Dept', 'company_id': cls.company_b.id,
+        })
+        cls.job_b = cls.env['hr.job'].create({
+            'name': 'Target Job', 'company_id': cls.company_b.id,
+        })
+
+        cls.source_employee = cls.env['hr.employee'].with_company(cls.company_a).create({
+            'name': 'Іван Петренко',
+            'company_id': cls.company_a.id,
+            'rnokpp': '1234567899',
+        })
+
+    def _make_wizard(self, **overrides):
+        vals = {
+            'source_employee_id': self.source_employee.id,
+            'source_company_id': self.company_a.id,
+            'target_company_id': self.company_b.id,
+            'dismissal_date': date(2026, 4, 30),
+            'hire_date': date(2026, 5, 1),
+            'new_department_id': self.dept_b.id,
+            'new_job_id': self.job_b.id,
+        }
+        vals.update(overrides)
+        return self.env['hr.employee.transfer.wizard'].create(vals)
+
+    def test_transfer_creates_new_employee(self):
+        wizard = self._make_wizard()
+        wizard.action_transfer()
+        new_employee = self.source_employee.next_employee_id
+        self.assertTrue(new_employee)
+        self.assertEqual(new_employee.company_id, self.company_b)
+        self.assertEqual(new_employee.name, 'Іван Петренко')
+        self.assertEqual(new_employee.rnokpp, '1234567899')
+        self.assertEqual(new_employee.previous_employee_id, self.source_employee)
+
+    def test_transfer_deactivates_source(self):
+        wizard = self._make_wizard()
+        wizard.action_transfer()
+        self.source_employee.invalidate_recordset(['active'])
+        self.assertFalse(self.source_employee.active)
+
+    def test_transfer_creates_hr_orders(self):
+        wizard = self._make_wizard()
+        wizard.action_transfer()
+        new_employee = self.source_employee.next_employee_id
+
+        dismissal_orders = self.env['hr.order'].search([
+            ('employee_id', '=', self.source_employee.id),
+            ('order_type', '=', 'dismissal'),
+        ])
+        self.assertTrue(dismissal_orders, 'Dismissal hr.order must be created')
+        self.assertEqual(dismissal_orders.date_dismissal, date(2026, 4, 30))
+
+        hiring_orders = self.env['hr.order'].search([
+            ('employee_id', '=', new_employee.id),
+            ('order_type', '=', 'hiring'),
+        ])
+        self.assertTrue(hiring_orders, 'Hiring hr.order must be created')
+        self.assertEqual(hiring_orders.date_start, date(2026, 5, 1))
+
+    def test_cannot_transfer_to_same_company(self):
+        with self.assertRaises(UserError):
+            self._make_wizard(target_company_id=self.company_a.id)
+
+    def test_cannot_transfer_twice(self):
+        wizard = self._make_wizard()
+        wizard.action_transfer()
+        with self.assertRaises(UserError):
+            wizard.action_transfer()
+
+    def test_hire_date_autocomputed(self):
+        wizard = self.env['hr.employee.transfer.wizard'].create({
+            'source_employee_id': self.source_employee.id,
+            'source_company_id': self.company_a.id,
+            'target_company_id': self.company_b.id,
+            'dismissal_date': date(2026, 4, 30),
+        })
+        self.assertEqual(wizard.hire_date, date(2026, 5, 1))
+
+    def test_hire_before_dismissal_rejected(self):
+        with self.assertRaises(UserError):
+            self._make_wizard(hire_date=date(2026, 4, 29))
+
+    def test_vacation_reset_is_default(self):
+        wizard = self._make_wizard()
+        self.assertEqual(wizard.vacation_transfer_mode, 'reset')

--- a/l10n_ua_hr_employee_transfer/views/hr_employee_views.xml
+++ b/l10n_ua_hr_employee_transfer/views/hr_employee_views.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="action_view_previous_employee" model="ir.actions.server">
+        <field name="name">Попередній запис співробітника</field>
+        <field name="model_id" ref="hr.model_hr_employee"/>
+        <field name="state">code</field>
+        <field name="code">
+if records.previous_employee_id:
+    action = {
+        'type': 'ir.actions.act_window',
+        'res_model': 'hr.employee',
+        'res_id': records.previous_employee_id.id,
+        'view_mode': 'form',
+        'context': {'allowed_company_ids': env.context.get('allowed_company_ids', []) + [records.previous_employee_id.company_id.id]},
+    }
+        </field>
+    </record>
+
+    <record id="action_view_next_employee" model="ir.actions.server">
+        <field name="name">Наступний запис співробітника</field>
+        <field name="model_id" ref="hr.model_hr_employee"/>
+        <field name="state">code</field>
+        <field name="code">
+if records.next_employee_id:
+    action = {
+        'type': 'ir.actions.act_window',
+        'res_model': 'hr.employee',
+        'res_id': records.next_employee_id.id,
+        'view_mode': 'form',
+        'context': {'allowed_company_ids': env.context.get('allowed_company_ids', []) + [records.next_employee_id.company_id.id]},
+    }
+        </field>
+    </record>
+
+    <record id="hr_employee_view_form_inherit_transfer" model="ir.ui.view">
+        <field name="name">hr.employee.form.inherit.transfer</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.view_employee_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button name="action_open_transfer_wizard"
+                        type="object"
+                        string="Перевести в іншу організацію"
+                        class="btn-secondary"
+                        groups="hr.group_hr_manager"
+                        invisible="not active or next_employee_id"/>
+            </xpath>
+            <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+                <button name="%(action_view_previous_employee)d" type="action"
+                        class="oe_stat_button" icon="fa-arrow-left"
+                        invisible="not previous_employee_id">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Попередня</span>
+                        <span class="o_stat_text">компанія</span>
+                    </div>
+                </button>
+                <button name="%(action_view_next_employee)d" type="action"
+                        class="oe_stat_button" icon="fa-arrow-right"
+                        invisible="not next_employee_id">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Наступна</span>
+                        <span class="o_stat_text">компанія</span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ua_hr_employee_transfer/wizard/__init__.py
+++ b/l10n_ua_hr_employee_transfer/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_employee_transfer_wizard

--- a/l10n_ua_hr_employee_transfer/wizard/hr_employee_transfer_wizard.py
+++ b/l10n_ua_hr_employee_transfer/wizard/hr_employee_transfer_wizard.py
@@ -1,0 +1,242 @@
+from datetime import timedelta
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
+
+
+PERSONAL_FIELDS = [
+    # Standard Odoo personal data
+    'name', 'gender', 'birthday', 'place_of_birth', 'country_of_birth',
+    'marital', 'private_phone', 'private_email', 'private_street',
+    'private_street2', 'private_city', 'private_zip', 'private_state_id',
+    'private_country_id',
+    # Ukrainian-specific personal data from l10n_ua_hr_base
+    'rnokpp', 'document_type', 'passport_series', 'passport_number',
+    'passport_issued_by', 'passport_issued_date', 'passport_record_number',
+    'registration_address', 'registration_region_id', 'registration_city',
+    'registration_zip', 'actual_address', 'actual_same_as_registration',
+    'education_level_id', 'diploma_series', 'diploma_number', 'diploma_date',
+    'military_status', 'military_category', 'military_rank_id',
+    'military_specialty', 'military_fitness', 'military_document_number',
+    'military_tcc_id', 'military_reservation', 'military_reservation_until',
+    'military_reservplus_id',
+    'disability_group', 'disability_reason', 'disability_document',
+    'disability_date_from', 'disability_date_to',
+    'chornobyl_category', 'veteran_status', 'spouse_rnokpp',
+]
+
+
+class HrEmployeeTransferWizard(models.TransientModel):
+    _name = 'hr.employee.transfer.wizard'
+    _description = 'Переведення співробітника в іншу компанію (КЗпП ст. 36 п. 5)'
+
+    source_employee_id = fields.Many2one(
+        'hr.employee', string='Співробітник (source)', required=True, readonly=True,
+    )
+    source_company_id = fields.Many2one(
+        'res.company', string='Компанія (source)', required=True, readonly=True,
+    )
+    target_company_id = fields.Many2one(
+        'res.company', string='Цільова компанія', required=True,
+        domain="[('id', '!=', source_company_id)]",
+    )
+
+    dismissal_date = fields.Date(
+        string='Дата звільнення', required=True, default=fields.Date.context_today,
+    )
+    dismissal_reason = fields.Text(
+        string='Підстава звільнення', required=True,
+        default='п. 5 ст. 36 КЗпП України — переведення на інше підприємство (за згодою працівника)',
+    )
+    hire_date = fields.Date(
+        string='Дата прийняття',
+        compute='_compute_hire_date', store=True, readonly=False,
+    )
+
+    new_department_id = fields.Many2one(
+        'hr.department', string='Підрозділ (target)',
+        domain="[('company_id', '=', target_company_id)]",
+    )
+    new_job_id = fields.Many2one(
+        'hr.job', string='Посада (target)',
+        domain="[('company_id', '=', target_company_id)]",
+    )
+
+    copy_bank_accounts = fields.Boolean(string='Копіювати банківські рахунки', default=True)
+    copy_documents = fields.Boolean(string='Копіювати особові документи', default=True)
+    copy_family_data = fields.Boolean(string='Копіювати сімейні дані (діти, подружжя)', default=True)
+
+    vacation_transfer_mode = fields.Selection(
+        [
+            ('reset', 'Залишок згоряє (закон 2022)'),
+            ('transfer', 'Перенести (за згодою сторін)'),
+        ],
+        string='Залишок відпустки', required=True, default='reset',
+        help='Зміни в КЗпП 2022 року: накопичений залишок при переведенні згоряє. '
+             'За згодою сторін може переноситися — оберіть "Перенести".',
+    )
+
+    @api.depends('dismissal_date')
+    def _compute_hire_date(self):
+        for wiz in self:
+            wiz.hire_date = (wiz.dismissal_date + timedelta(days=1)) if wiz.dismissal_date else False
+
+    @api.constrains('target_company_id', 'source_company_id')
+    def _check_different_company(self):
+        for wiz in self:
+            if wiz.target_company_id == wiz.source_company_id:
+                raise UserError(_('Цільова компанія має відрізнятися від поточної.'))
+
+    @api.constrains('hire_date', 'dismissal_date')
+    def _check_dates(self):
+        for wiz in self:
+            if wiz.hire_date and wiz.dismissal_date and wiz.hire_date < wiz.dismissal_date:
+                raise UserError(_('Дата прийняття не може бути раніше за дату звільнення.'))
+
+    def _prepare_new_employee_vals(self):
+        self.ensure_one()
+        source = self.source_employee_id
+        vals = {
+            'company_id': self.target_company_id.id,
+            'department_id': self.new_department_id.id or False,
+            'job_id': self.new_job_id.id or False,
+            'previous_employee_id': source.id,
+        }
+        for fname in PERSONAL_FIELDS:
+            if fname not in source._fields:
+                continue
+            value = source[fname]
+            if hasattr(value, 'id'):
+                vals[fname] = value.id if value else False
+            else:
+                vals[fname] = value
+        if not self.copy_documents:
+            for fname in ('passport_series', 'passport_number', 'passport_issued_by',
+                          'passport_issued_date', 'passport_record_number',
+                          'diploma_series', 'diploma_number', 'diploma_date',
+                          'education_level_id'):
+                vals.pop(fname, None)
+        if not self.copy_family_data:
+            vals.pop('spouse_rnokpp', None)
+            vals.pop('marital', None)
+        return vals
+
+    def _copy_children(self, new_employee):
+        if not self.copy_family_data:
+            return
+        Child = self.env['hr.employee.child']
+        for child in self.source_employee_id.children_ids:
+            copy_vals = child.copy_data()[0]
+            copy_vals['employee_id'] = new_employee.id
+            Child.sudo().create(copy_vals)
+
+    def _copy_bank_accounts(self, new_employee):
+        if not self.copy_bank_accounts or not self.source_employee_id.work_contact_id:
+            return
+        source_partner = self.source_employee_id.work_contact_id
+        target_partner = new_employee.work_contact_id
+        if not target_partner:
+            return
+        for bank in source_partner.bank_ids:
+            copy_vals = bank.copy_data()[0]
+            copy_vals['partner_id'] = target_partner.id
+            copy_vals['company_id'] = self.target_company_id.id
+            self.env['res.partner.bank'].sudo().create(copy_vals)
+
+    def _create_dismissal_order(self):
+        return self.env['hr.order'].with_company(self.source_company_id).sudo().create({
+            'order_type': 'dismissal',
+            'subject': 'Про припинення трудового договору (переведенням)',
+            'employee_id': self.source_employee_id.id,
+            'department_id': self.source_employee_id.department_id.id,
+            'job_id': self.source_employee_id.job_id.id,
+            'date': self.dismissal_date,
+            'date_dismissal': self.dismissal_date,
+            'dismissal_reason': self.dismissal_reason,
+        })
+
+    def _create_hiring_order(self, new_employee):
+        return self.env['hr.order'].with_company(self.target_company_id).sudo().create({
+            'order_type': 'hiring',
+            'subject': 'Про прийняття на роботу (переведенням)',
+            'employee_id': new_employee.id,
+            'department_id': self.new_department_id.id,
+            'job_id': self.new_job_id.id,
+            'date': self.hire_date,
+            'date_start': self.hire_date,
+        })
+
+    def _transfer_vacation_balance(self, new_employee):
+        if self.vacation_transfer_mode != 'transfer':
+            return
+        Balance = self.env['hr.vacation.balance']
+        if Balance._name not in self.env.registry:
+            return
+        year = self.hire_date.year
+        source_balances = Balance.sudo().search([
+            ('employee_id', '=', self.source_employee_id.id),
+            ('year', '=', year),
+        ])
+        for bal in source_balances:
+            remaining = (bal.total_available or 0) - (bal.used_days or 0)
+            if remaining <= 0:
+                continue
+            Balance.sudo().create({
+                'employee_id': new_employee.id,
+                'leave_type_id': bal.leave_type_id.id,
+                'year': year,
+                'entitled_days': 0,
+                'carried_over': remaining,
+            })
+
+    def action_transfer(self):
+        self.ensure_one()
+        if not self.hire_date:
+            raise UserError(_('Вкажіть дату прийняття.'))
+        source = self.source_employee_id
+        if source.next_employee_id:
+            raise UserError(_(
+                'Цей співробітник вже переведений (див. "Наступний запис"). '
+                'Повторне переведення з тієї ж картки не дозволено.'
+            ))
+
+        new_employee_vals = self._prepare_new_employee_vals()
+        new_employee = self.env['hr.employee'].sudo().with_company(
+            self.target_company_id,
+        ).create(new_employee_vals)
+
+        source.sudo().write({'next_employee_id': new_employee.id})
+
+        self._copy_children(new_employee)
+        self._copy_bank_accounts(new_employee)
+
+        dismissal_order = self._create_dismissal_order()
+        hiring_order = self._create_hiring_order(new_employee)
+
+        self._transfer_vacation_balance(new_employee)
+
+        source.sudo().write({'active': False})
+
+        source.message_post(body=_(
+            'Переведено в компанію <b>%(company)s</b>. Дата звільнення: %(date)s. '
+            'Наказ про звільнення: %(order)s.',
+            company=self.target_company_id.display_name,
+            date=self.dismissal_date,
+            order=dismissal_order.name or 'New',
+        ))
+        new_employee.message_post(body=_(
+            'Прийнято переведенням з компанії <b>%(company)s</b>. Дата прийняття: %(date)s. '
+            'Наказ про прийняття: %(order)s.',
+            company=self.source_company_id.display_name,
+            date=self.hire_date,
+            order=hiring_order.name or 'New',
+        ))
+
+        return {
+            'type': 'ir.actions.act_window',
+            'name': new_employee.name,
+            'res_model': 'hr.employee',
+            'res_id': new_employee.id,
+            'view_mode': 'form',
+            'target': 'current',
+        }

--- a/l10n_ua_hr_employee_transfer/wizard/hr_employee_transfer_wizard_views.xml
+++ b/l10n_ua_hr_employee_transfer/wizard/hr_employee_transfer_wizard_views.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="hr_employee_transfer_wizard_view_form" model="ir.ui.view">
+        <field name="name">hr.employee.transfer.wizard.form</field>
+        <field name="model">hr.employee.transfer.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Переведення в іншу організацію">
+                <sheet>
+                    <div class="alert alert-info" role="alert">
+                        <strong>КЗпП ст. 36 п. 5.</strong> Переведення проводиться через звільнення з source-компанії
+                        та прийняття в target-компанії. Повний розрахунок виконується на старому місці роботи.
+                        Залишок відпустки згоряє (зміни 2022 р.), якщо сторони не домовилися про перенесення.
+                    </div>
+                    <group>
+                        <group string="Source (звільнення)">
+                            <field name="source_employee_id" readonly="1" options="{'no_open': True}"/>
+                            <field name="source_company_id" readonly="1" options="{'no_open': True}"/>
+                            <field name="dismissal_date"/>
+                            <field name="dismissal_reason"/>
+                        </group>
+                        <group string="Target (прийняття)">
+                            <field name="target_company_id" options="{'no_create': True}"/>
+                            <field name="hire_date"/>
+                            <field name="new_department_id" options="{'no_create': True}"/>
+                            <field name="new_job_id" options="{'no_create': True}"/>
+                        </group>
+                    </group>
+                    <group string="Що копіювати">
+                        <group>
+                            <field name="copy_bank_accounts"/>
+                            <field name="copy_documents"/>
+                            <field name="copy_family_data"/>
+                        </group>
+                        <group>
+                            <field name="vacation_transfer_mode" widget="radio"/>
+                        </group>
+                    </group>
+                </sheet>
+                <footer>
+                    <button name="action_transfer" type="object" string="Перевести"
+                            class="btn-primary"
+                            confirm="Підтвердити переведення? Буде створено нового співробітника в цільовій компанії, сформовано накази та деактивовано поточну картку."/>
+                    <button string="Скасувати" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Closes #32

## Summary

Новий модуль `l10n_ua_hr_employee_transfer` — wizard для переведення співробітника з однієї компанії в іншу за правилами КЗпП ст. 36 п. 5.

## Що робить wizard

1. **Створює нового `hr.employee`** у цільовій компанії з копіюванням персональних даних (ім'я, RNOKPP, паспорт, адреса реєстрації/факт., військовий облік, освіта, інвалідність, ветеранський статус, чорнобильська категорія).
2. **Опційно копіює:**
   - Банківські рахунки (`copy_bank_accounts`)
   - Особові документи: паспорт + диплом (`copy_documents`)
   - Сімейні дані: подружжя + діти (`copy_family_data`)
3. **Створює `hr.order` типу `dismissal`** у source-компанії з підставою `п. 5 ст. 36 КЗпП України`.
4. **Створює `hr.order` типу `hiring`** у target-компанії.
5. **Деактивує source `hr.employee`** (`active=False`).
6. **Cross-company зв'язок:** `previous_employee_id` / `next_employee_id` (з `check_company=False`) — для смарт-кнопок навігації між картками.
7. **Vacation balance** — два режими:
   - `reset` (default, відповідає КЗпП 2022)
   - `transfer` (за згодою сторін) — переносить залишки в нову `hr.vacation.balance`

## UI

- Кнопка **"Перевести в іншу організацію"** в header форми співробітника. Видима лише для `hr.group_hr_manager` і коли співробітник активний та ще не переведений.
- Smart-кнопки **"Попередня компанія" / "Наступна компанія"** — навігація між зв'язаними картками.

## Що НЕ зроблено (можна окремими PR при потребі)

- **Final settlement payslip** — не генерується автоматично (модуль не залежить від `l10n_ua_hr_salary`, щоб не тягнути зайве). Бухгалтер створює final payslip вручну в source-компанії.
- **Trudova book запис** — окремої моделі ТК у репо немає; у `hr.order` записів про звільнення/прийняття буде достатньо для друку наказів.
- **Військовий облік** — поля копіюються, але новій компанії потрібно зробити повторне приписання вручну.

## Архітектурні обмеження

В Odoo 19 `hr.employee.company_id` — NOT NULL (один запис = одна компанія). Тому переведення = два окремих записи з cross-company link, **не** один запис з M2M. Це вимога Odoo, не локалізації.

## Test plan

- [x] Unit tests `tests/test_transfer_wizard.py`: **8/8 pass**
  - `test_transfer_creates_new_employee` — нова картка створена в target з персональними даними
  - `test_transfer_deactivates_source` — source `active=False`
  - `test_transfer_creates_hr_orders` — обидва hr.order створені з правильними даними
  - `test_cannot_transfer_to_same_company` — UserError якщо target == source
  - `test_cannot_transfer_twice` — UserError на повторне переведення
  - `test_hire_date_autocomputed` — hire_date = dismissal_date + 1
  - `test_hire_before_dismissal_rejected` — UserError якщо hire < dismissal
  - `test_vacation_reset_is_default` — default = reset (КЗпП 2022)
- [ ] Manual UI test після merge — кнопка → wizard → переведення → перевірка карток в обох компаніях