### PR TITLE
fix(l10n_ua_hr_holidays): correct expected employer_days in sick leave test

### DIFF
--- a/l10n_ua_hr_holidays/tests/test_hr_sick_leave.py
+++ b/l10n_ua_hr_holidays/tests/test_hr_sick_leave.py
@@ -107,14 +107,19 @@ class TestHrSickLeave(TransactionCase):
         self.assertEqual(sick_leave.fss_days, 2)
 
     def test_short_sick_leave_employer_only(self):
-        """Test short sick leave (<=5 days) paid only by employer"""
+        """Test short sick leave (<=5 days) paid only by employer.
+
+        For a 4-day leave (Jan 15-18), employer_days = min(5, 4) = 4
+        and fss_days = 0 (нічого не залишається для ФСС).
+        """
         sick_leave = self.env['hr.sick.leave'].create({
             'employee_id': self.employee.id,
             'date_from': date(2026, 1, 15),
             'date_to': date(2026, 1, 18),
             'sick_leave_type': 'illness',
         })
-        self.assertEqual(sick_leave.employer_days, 5)
+        self.assertEqual(sick_leave.calendar_days, 4)
+        self.assertEqual(sick_leave.employer_days, 4)
         self.assertEqual(sick_leave.fss_days, 0)
 
     def test_pregnancy_fss_only(self):


### PR DESCRIPTION
## Summary

`test_short_sick_leave_employer_only` створював 4-денний лікарняний (Jan 15–18) і очікував `employer_days == 5`, але `_compute_employer_days` рахує `min(5, calendar_days)`, тобто для 4 днів — 4. Тест був арифметично некоректний.

Виправлено очікування на `employer_days == 4` і додано `assertEqual(calendar_days, 4)` для самодокументації.

## Перевірка

Запустив через odoo shell:

\`\`\`
4-day sick leave Jan 15-18:
  calendar_days = 4
  employer_days = 4
  fss_days = 0

7-day sick leave Jan 15-21 (control):
  calendar_days = 7
  employer_days = 5
  fss_days = 2
\`\`\`

Поведінка `hr.sick.leave._compute_employer_days` НЕ змінювалась — це фікс лише тесту, формула вже була правильна.

## Test plan

- [x] Перевірив математику моделі через odoo shell
- [ ] Run `--test-tags=/l10n_ua_hr_holidays:TestHrSickLeave` після merge