### PR TITLE
fix(l10n_ua_accounting): inherit analytic.mixin to fix install on EE (#39)

### DIFF
--- a/l10n_ua_accounting/models/account_payment.py
+++ b/l10n_ua_accounting/models/account_payment.py
@@ -16,6 +16,7 @@ class AccountPayment(models.Model):
     standard Odoo widget, search method, and gin index — plays nicely with
     Enterprise Edition modules that may also extend account.payment.
     """
+    _name = 'account.payment'
     _inherit = ['account.payment', 'analytic.mixin']
 
     # --- Cash Order fields ---

--- a/l10n_ua_accounting/models/account_payment.py
+++ b/l10n_ua_accounting/models/account_payment.py
@@ -11,8 +11,12 @@ class AccountPayment(models.Model):
     - PKO (ПКО) = Прибутковий касовий ордер = Cash Receipt Order (inbound)
     - VKO (ВКО) = Видатковий касовий ордер = Cash Disbursement Order (outbound)
     - ПД = Платіжне доручення = Bank Payment Order (outbound bank transfer)
+
+    Inherits analytic.mixin to provide analytic_distribution field with the
+    standard Odoo widget, search method, and gin index — plays nicely with
+    Enterprise Edition modules that may also extend account.payment.
     """
-    _inherit = 'account.payment'
+    _inherit = ['account.payment', 'analytic.mixin']
 
     # --- Cash Order fields ---
     ua_cash_order_number = fields.Char(
@@ -100,9 +104,13 @@ class AccountPayment(models.Model):
         store=True,
     )
 
-    # --- Analytic distribution (стаття руху грошових коштів) ---
+    # analytic_distribution provided by analytic.mixin (Json + widget + gin index)
+    # Override label to Ukrainian via attribute redefinition
     analytic_distribution = fields.Json(
         string='Аналітичний розподіл',
+        compute='_compute_analytic_distribution',
+        search='_search_analytic_distribution',
+        store=True, copy=True, readonly=False,
         help='Стаття руху грошових коштів та інша аналітика. '
              'Передається на counterpart та write-off рядки журнальних проводок '
              'при підтвердженні платежу. Не передається на ліквідну (cash) сторону.',


### PR DESCRIPTION
Closes #39

## Проблема

Користувач @yakravets повідомив, що після merge PR #35 встановлення `l10n_ua_accounting` на **Odoo Enterprise** падає з помилкою валідації view:

\`\`\`
Поле "analytic_distribution" не існує в моделі "account.payment"
\`\`\`

В Community помилка не відтворюється — швидше за все конфлікт виникає через те, що EE-модулі (account_accountant та інші) розширюють \`account.payment\` і моя ad-hoc дефініція \`analytic_distribution = fields.Json(...)\` без compute/search не вписується в очікуваний контракт.

## Фікс

Переходимо на канонічний шлях — успадковуємо **\`analytic.mixin\`** (так само як \`account.move.line\`):

\`\`\`python
_inherit = ['account.payment', 'analytic.mixin']
\`\`\`

Mixin надає:
- \`analytic_distribution\` як \`fields.Json\` з \`_compute_analytic_distribution\` (no-op) та \`_search_analytic_distribution\`
- \`distribution_analytic_account_ids\` (computed M2M на analytic accounts)
- gin-індекс на JSON-колонці для пошуку
- Інтеграцію з widget \`analytic_distribution\`

Локальне поле \`analytic_distribution\` залишаємо для **української назви** + help-text, але delegated на mixin-методи через \`compute\`/\`search\` атрибути.

## Test plan

- [x] 5/5 unit-тестів `TestCashAnalytic` проходять локально (CE)
- [x] @yakravets — підтвердити що встановлення на EE проходить без помилки