### PR TITLE
fix(l10n_ua_accounting): default to cash journal when opening ПКО/ВКО action

### DIFF
--- a/l10n_ua_accounting/models/account_payment.py
+++ b/l10n_ua_accounting/models/account_payment.py
@@ -163,32 +163,6 @@ class AccountPayment(models.Model):
             line_vals.setdefault('analytic_distribution', dict(self.analytic_distribution))
         return result
 
-    # --- Default journal for ПКО/ВКО actions ---
-
-    @api.depends('company_id', 'partner_id')
-    def _compute_journal_id(self):
-        """Prefer cash journal when opening form via ПКО/ВКО action.
-
-        Stock _compute_journal_id picks the first bank/cash/credit journal
-        — usually a bank journal first. When opening from ПКО/ВКО list,
-        we set context flag l10n_ua_default_cash_journal=True so the form
-        starts with a cash journal pre-selected.
-        """
-        super()._compute_journal_id()
-        if not self.env.context.get('l10n_ua_default_cash_journal'):
-            return
-        for payment in self:
-            if payment.journal_id.type == 'cash':
-                continue
-            cash_journal = self.env['account.journal'].search([
-                *self.env['account.journal']._check_company_domain(
-                    payment.company_id or self.env.company,
-                ),
-                ('type', '=', 'cash'),
-            ], limit=1)
-            if cash_journal:
-                payment.journal_id = cash_journal
-
     # --- Create with auto-sequencing ---
 
     @api.model_create_multi

--- a/l10n_ua_accounting/models/account_payment.py
+++ b/l10n_ua_accounting/models/account_payment.py
@@ -163,6 +163,32 @@ class AccountPayment(models.Model):
             line_vals.setdefault('analytic_distribution', dict(self.analytic_distribution))
         return result
 
+    # --- Default journal for ПКО/ВКО actions ---
+
+    @api.depends('company_id', 'partner_id')
+    def _compute_journal_id(self):
+        """Prefer cash journal when opening form via ПКО/ВКО action.
+
+        Stock _compute_journal_id picks the first bank/cash/credit journal
+        — usually a bank journal first. When opening from ПКО/ВКО list,
+        we set context flag l10n_ua_default_cash_journal=True so the form
+        starts with a cash journal pre-selected.
+        """
+        super()._compute_journal_id()
+        if not self.env.context.get('l10n_ua_default_cash_journal'):
+            return
+        for payment in self:
+            if payment.journal_id.type == 'cash':
+                continue
+            cash_journal = self.env['account.journal'].search([
+                *self.env['account.journal']._check_company_domain(
+                    payment.company_id or self.env.company,
+                ),
+                ('type', '=', 'cash'),
+            ], limit=1)
+            if cash_journal:
+                payment.journal_id = cash_journal
+
     # --- Create with auto-sequencing ---
 
     @api.model_create_multi

--- a/l10n_ua_accounting/views/account_payment_views.xml
+++ b/l10n_ua_accounting/views/account_payment_views.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <!-- Restrict journal_id to allowed types from context (set by ПКО/ВКО actions) -->
+    <record id="view_account_payment_form_ua_journal_domain" model="ir.ui.view">
+        <field name="name">account.payment.form.ua.journal.domain</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form"/>
+        <field name="arch" type="xml">
+            <field name="journal_id" position="attributes">
+                <attribute name="domain">[('type', 'in', context.get('allowed_journal_types', ['bank', 'cash', 'credit']))]</attribute>
+            </field>
+        </field>
+    </record>
+
     <!-- Extend payment form with Ukrainian fields -->
     <record id="view_account_payment_form_ua" model="ir.ui.view">
         <field name="name">account.payment.form.ua</field>
@@ -96,7 +108,7 @@
             'default_payment_type': 'inbound',
             'default_partner_type': 'customer',
             'search_default_journal_id': False,
-            'l10n_ua_default_cash_journal': True,
+            'allowed_journal_types': ['cash'],
         }</field>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'list', 'view_id': ref('view_account_payment_pko_list')}),
@@ -113,7 +125,7 @@
             'default_payment_type': 'outbound',
             'default_partner_type': 'supplier',
             'search_default_journal_id': False,
-            'l10n_ua_default_cash_journal': True,
+            'allowed_journal_types': ['cash'],
         }</field>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'list', 'view_id': ref('view_account_payment_vko_list')}),

--- a/l10n_ua_accounting/views/account_payment_views.xml
+++ b/l10n_ua_accounting/views/account_payment_views.xml
@@ -96,6 +96,7 @@
             'default_payment_type': 'inbound',
             'default_partner_type': 'customer',
             'search_default_journal_id': False,
+            'l10n_ua_default_cash_journal': True,
         }</field>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'list', 'view_id': ref('view_account_payment_pko_list')}),
@@ -112,6 +113,7 @@
             'default_payment_type': 'outbound',
             'default_partner_type': 'supplier',
             'search_default_journal_id': False,
+            'l10n_ua_default_cash_journal': True,
         }</field>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'list', 'view_id': ref('view_account_payment_vko_list')}),


### PR DESCRIPTION
## Проблема (доповідь @yakravets)

При відкритті форми створення з меню **ПКО** або **ВКО** Odoo підтягував перший доступний журнал — типово **банківський**. Тобто користувач натискав "Створити ПКО" і отримував форму з банківським журналом, а ПКО за визначенням — готівка.

## Фікс

1. У контекст action-ів `action_account_payment_pko` і `action_account_payment_vko` додано прапор `l10n_ua_default_cash_journal: True`.
2. Override `_compute_journal_id` після виклику `super()` перевіряє прапор і, якщо журнал не cash, шукає cash-журнал у поточній компанії і виставляє його.

Логіка спрацьовує тільки в контексті ПКО/ВКО — звичайне створення платежу через меню Payments не зачіпається.

## Перевірка через odoo shell

\`\`\`
=== WITHOUT context ===
  journal = Test Bank (type=bank)
=== WITH l10n_ua_default_cash_journal=True ===
  journal = Test Cash (type=cash)
\`\`\`