### PR TITLE
Зв'язок відпусток і наказів на відпустки та автоматичне формування таблиці відпусток в особовій справі (форма П2)  - issue #36

### DIFF
--- a/l10n_ua_hr_base/report/hr_employee_p2_report.xml
+++ b/l10n_ua_hr_base/report/hr_employee_p2_report.xml
@@ -352,14 +352,6 @@
         		    <td style="border: 1px solid #000; padding: 3px;"></td>
     		    	</tr>
 		    </t>
-
-                    <tr>
-                        <td style="border: 1px solid #000; padding: 3px; height: 20px;"></td>
-                        <td style="border: 1px solid #000; padding: 3px;"></td>
-                        <td style="border: 1px solid #000; padding: 3px;"></td>
-                        <td style="border: 1px solid #000; padding: 3px;"></td>
-                        <td style="border: 1px solid #000; padding: 3px;"></td>
-                    </tr>
                 </table>
                 
                 <t t-if="employee.disability_group and employee.disability_group != 'none'">

--- a/l10n_ua_hr_base/report/hr_employee_p2_report.xml
+++ b/l10n_ua_hr_base/report/hr_employee_p2_report.xml
@@ -309,13 +309,50 @@
                         <th style="border: 1px solid #000; padding: 3px;">Дата закінчення</th>
                         <th style="border: 1px solid #000; padding: 3px;">Підстава</th>
                     </tr>
-                    <tr>
-                        <td style="border: 1px solid #000; padding: 3px; height: 20px;"></td>
-                        <td style="border: 1px solid #000; padding: 3px;"></td>
-                        <td style="border: 1px solid #000; padding: 3px;"></td>
-                        <td style="border: 1px solid #000; padding: 3px;"></td>
-                        <td style="border: 1px solid #000; padding: 3px;"></td>
-                    </tr>
+		    <t t-set="leaves" t-value="env['hr.leave'].search([
+    			('employee_id', '=', employee.id),
+    			('state', '=', 'validate'),
+			], order='date_from asc')"/>
+		    <t t-foreach="leaves" t-as="leave">
+    		        <tr>
+        		    <td style="border: 1px solid #000; padding: 3px;">
+            			<t t-esc="leave.holiday_status_id.name or ''"/>
+        		    </td>
+        		    <td style="border: 1px solid #000; padding: 3px;">
+            			<t t-esc="leave.vacation_year or (leave.date_from.year if leave.date_from else '')"/>
+        		    </td>
+        		    <td style="border: 1px solid #000; padding: 3px;">
+            			<t t-if="leave.date_from"><t t-esc="leave.date_from.strftime('%d.%m.%Y')"/></t>
+        		    </td>
+        		    <td style="border: 1px solid #000; padding: 3px;">
+            			<t t-if="leave.date_to"><t t-esc="leave.date_to.strftime('%d.%m.%Y')"/></t>
+        		    </td>
+        		    <td style="border: 1px solid #000; padding: 3px;">
+            			<t t-if="leave.order_id">
+                		    наказ № <t t-esc="leave.order_id.name"/>
+                		    від <t t-esc="leave.order_id.date.strftime('%d.%m.%Y')"/>
+            	        	</t>
+
+            			<t t-elif="leave.order_number">
+                		    наказ № <t t-esc="leave.order_number"/>
+                		    <t t-if="leave.order_date">
+                    		        від <t t-esc="leave.order_date.strftime('%d.%m.%Y')"/>
+                		    </t>
+            			</t>
+        		    </td>
+    			</tr>
+		    </t>
+
+		    <t t-if="not leaves">
+    			<tr>
+        		    <td style="border: 1px solid #000; padding: 3px; height: 20px;"></td>
+        		    <td style="border: 1px solid #000; padding: 3px;"></td>
+        		    <td style="border: 1px solid #000; padding: 3px;"></td>
+        		    <td style="border: 1px solid #000; padding: 3px;"></td>
+        		    <td style="border: 1px solid #000; padding: 3px;"></td>
+    		    	</tr>
+		    </t>
+
                     <tr>
                         <td style="border: 1px solid #000; padding: 3px; height: 20px;"></td>
                         <td style="border: 1px solid #000; padding: 3px;"></td>

--- a/l10n_ua_hr_documents/data/hr_order_template_data.xml
+++ b/l10n_ua_hr_documents/data/hr_order_template_data.xml
@@ -388,20 +388,31 @@
             </tr>
         </table>
 
-        <p style="margin: 15px 0 5px 0;"><strong>Вид відпустки:</strong> щорічна основна відпустка</p>
+	<p style="margin: 15px 0 5px 0;"><strong>Вид відпустки:</strong> 
+    	    <t t-esc="order.holiday_status_id.name if order.holiday_status_id else 'щорічна основна відпустка'"/>
+	</p>
 
         <table style="width: 100%; border-collapse: collapse; margin: 10px 0;">
             <tr>
                 <td style="width: 50%; padding: 5px;">Тривалість відпустки:</td>
-                <td style="width: 50%; padding: 5px; border-bottom: 1px solid #000;">____ календарних днів</td>
+		<td style="width: 50%; padding: 5px; border-bottom: 1px solid #000;">
+		    <t t-if="order.leave_id and order.leave_id.calendar_days">
+        		<t t-esc="order.leave_id.calendar_days"/> календарних днів
+    	            </t>
+       		    <t t-else="">____ календарних днів</t>
+		</td>
             </tr>
             <tr>
                 <td style="padding: 5px;">Дата початку відпустки:</td>
-                <td style="padding: 5px; border-bottom: 1px solid #000;">"___" ____________ 20__ р.</td>
+		<td style="padding: 5px; border-bottom: 1px solid #000;">
+		    <t t-esc="format_date_ua(order.vacation_date_from)"/>
+		</td>
             </tr>
             <tr>
                 <td style="padding: 5px;">Дата закінчення відпустки:</td>
-                <td style="padding: 5px; border-bottom: 1px solid #000;">"___" ____________ 20__ р.</td>
+		<td style="padding: 5px; border-bottom: 1px solid #000;">
+		    <t t-esc="format_date_ua(order.vacation_date_to)"/>
+		</td>
             </tr>
         </table>
 

--- a/l10n_ua_hr_documents/i18n/uk_UA.po
+++ b/l10n_ua_hr_documents/i18n/uk_UA.po
@@ -1048,3 +1048,7 @@ msgstr "Дата закінчення відпустки"
 msgid "Leave Record"
 msgstr "Запис відпустки"
 
+#. module: l10n_ua_hr_documents
+#: model:ir.model.fields,field_description:l10n_ua_hr_documents.field_hr_order__holiday_status_id
+msgid "Leave Type"
+msgstr "Тип відпустки"

--- a/l10n_ua_hr_documents/i18n/uk_UA.po
+++ b/l10n_ua_hr_documents/i18n/uk_UA.po
@@ -1032,3 +1032,19 @@ msgstr "Запис трудової історії"
 #: model:ir.ui.menu,name:l10n_ua_hr_documents.menu_hr_order
 msgid "HR Orders"
 msgstr "Накази по персоналу"
+
+#. module: l10n_ua_hr_documents
+#: model:ir.model.fields,field_description:l10n_ua_hr_documents.field_hr_order__vacation_date_from
+msgid "Vacation Start Date"
+msgstr "Дата початку відпустки"
+
+#. module: l10n_ua_hr_documents
+#: model:ir.model.fields,field_description:l10n_ua_hr_documents.field_hr_order__vacation_date_to
+msgid "Vacation End Date"
+msgstr "Дата закінчення відпустки"
+
+#. module: l10n_ua_hr_documents
+#: model:ir.model.fields,field_description:l10n_ua_hr_documents.field_hr_order__leave_id
+msgid "Leave Record"
+msgstr "Запис відпустки"
+

--- a/l10n_ua_hr_documents/models/hr_order.py
+++ b/l10n_ua_hr_documents/models/hr_order.py
@@ -173,9 +173,10 @@ class HrOrder(models.Model):
                     and o.leave_id.state not in ('validate', 'validate1')
                 ):
                     order.leave_id.with_context(_sync_order_leave=True).write({
-                        'date_from': order.vacation_date_from,
-                        'date_to': order.vacation_date_to,
+                        'date_from': fields.Datetime.from_string(str(order.vacation_date_from)) if order.vacation_date_from else False,
+                        'date_to': fields.Datetime.from_string(str(order.vacation_date_to)) if order.vacation_date_to else False,
                     })
+
         return result
 
     def action_confirm(self):

--- a/l10n_ua_hr_documents/models/hr_order.py
+++ b/l10n_ua_hr_documents/models/hr_order.py
@@ -91,7 +91,9 @@ class HrOrder(models.Model):
                 and self.job_id.company_id != self.company_id:
             self.job_id = False
 
-    subject = fields.Char(string='Subject', required=True, tracking=True, compute='_compute_subject', store=True, readonly=False)
+    subject = fields.Char(string='Subject', required=True, tracking=True, compute='_compute_subject', store=True, readonly=False, precompute=True)
+
+
 
     ORDER_TYPE_SUBJECTS = {
         'hiring': 'Про прийняття на роботу',

--- a/l10n_ua_hr_documents/models/hr_order.py
+++ b/l10n_ua_hr_documents/models/hr_order.py
@@ -141,8 +141,8 @@ class HrOrder(models.Model):
                 leave_vals_list.append({
                     'employee_id': vals.get('employee_id'),
                     'holiday_status_id': vals.get('holiday_status_id'),
-                    'date_from': vals.get('vacation_date_from'),
-                    'date_to': vals.get('vacation_date_to'),
+                    'request_date_from': vals.get('vacation_date_from'),
+                    'request_date_to': vals.get('vacation_date_to'),
                 })
                 leave_indices.append(idx)
 
@@ -153,7 +153,8 @@ class HrOrder(models.Model):
             for idx, leave in zip(leave_indices, leaves):
                 vals_list[idx]['leave_id'] = leave.id
 
-        orders = super().create(vals_list)
+        # Add _sync_order_leave context to prevent duplicate orders on inverse related fields write
+        orders = super(HrOrder, self.with_context(_sync_order_leave=True)).create(vals_list)
 
         # Back-link leaves → orders in a single write per leave
         for order in orders:

--- a/l10n_ua_hr_documents/models/hr_order.py
+++ b/l10n_ua_hr_documents/models/hr_order.py
@@ -52,6 +52,27 @@ class HrOrder(models.Model):
         help='Legal basis for dismissal (e.g., "за власним бажанням, ст. 38 КЗпП України")'
     )
 
+    # Vacation-specific fields
+    vacation_date_from = fields.Date(string='Vacation Start Date', tracking=True)
+    vacation_date_to = fields.Date(string='Vacation End Date', tracking=True)
+    leave_id = fields.Many2one(
+        'hr.leave',
+        string='Leave Record',
+        ondelete='set null',
+        copy=False,
+        index=True,
+    )
+    # Related field — eliminates duplication (рек. №5)
+    holiday_status_id = fields.Many2one(
+        'hr.leave.type',
+        string='Leave Type',
+        related='leave_id.holiday_status_id',
+        store=True,
+        readonly=False,   # writable for orders being created standalone before leave is linked
+        precompute=True,
+        tracking=True,
+    )
+
     @api.onchange('employee_id')
     def _onchange_employee_id(self):
         """Auto-fill department and job position from employee."""
@@ -109,13 +130,67 @@ class HrOrder(models.Model):
                 order_type = vals.get('order_type', 'other')
                 sequence_code = f'hr.order.{order_type}'
                 vals['name'] = self.env['ir.sequence'].next_by_code(sequence_code) or 'New'
-        return super().create(vals_list)
+
+        # Collect indices of vacation orders that need a leave auto-created
+        leave_vals_list = []
+        leave_indices = []
+        for idx, vals in enumerate(vals_list):
+            if (vals.get('order_type') == 'vacation'
+                    and not vals.get('leave_id')
+                    and not self.env.context.get('_creating_order_from_leave')):
+                leave_vals_list.append({
+                    'employee_id': vals.get('employee_id'),
+                    'holiday_status_id': vals.get('holiday_status_id'),
+                    'date_from': vals.get('vacation_date_from'),
+                    'date_to': vals.get('vacation_date_to'),
+                })
+                leave_indices.append(idx)
+
+        if leave_vals_list:
+            leaves = self.env['hr.leave'].with_context(
+                _creating_leave_from_order=True
+            ).create(leave_vals_list)
+            for idx, leave in zip(leave_indices, leaves):
+                vals_list[idx]['leave_id'] = leave.id
+
+        orders = super().create(vals_list)
+
+        # Back-link leaves → orders in a single write per leave
+        for order in orders:
+            if order.leave_id and not order.leave_id.order_id:
+                order.leave_id.with_context(_sync_order_leave=True).write(
+                    {'order_id': order.id}
+                )
+        return orders
+
+    def write(self, vals):
+        result = super().write(vals)
+        if not self.env.context.get('_sync_order_leave'):
+            if {'vacation_date_from', 'vacation_date_to'} & vals.keys():
+                for order in self.filtered(lambda o: o.order_type == 'vacation' and o.leave_id):
+                    order.leave_id.with_context(_sync_order_leave=True).write({
+                        'date_from': order.vacation_date_from,
+                        'date_to': order.vacation_date_to,
+                    })
+        return result
 
     def action_confirm(self):
         self.write({'state': 'confirmed'})
 
     def action_cancel(self):
         self.write({'state': 'cancelled'})
+        for order in self.filtered(lambda o: o.leave_id):
+            order.leave_id.message_post(
+                body=_('Linked vacation order %s was cancelled. Leave state is unchanged.', order.name)
+            )
+        return res
+
+    def unlink(self):
+        leaves = self.mapped('leave_id')
+        res = super().unlink()
+        for leave in leaves.exists():
+            leave.message_post(body=_('Linked vacation order was deleted.'))
+        return res
 
     def action_draft(self):
         self.write({'state': 'draft'})

--- a/l10n_ua_hr_documents/models/hr_order.py
+++ b/l10n_ua_hr_documents/models/hr_order.py
@@ -1,5 +1,4 @@
 from odoo import models, fields, api, _
-from odoo.exceptions import UserError
 
 class HrOrder(models.Model):
     _name = 'hr.order'
@@ -166,7 +165,11 @@ class HrOrder(models.Model):
         result = super().write(vals)
         if not self.env.context.get('_sync_order_leave'):
             if {'vacation_date_from', 'vacation_date_to'} & vals.keys():
-                for order in self.filtered(lambda o: o.order_type == 'vacation' and o.leave_id):
+                for order in self.filtered(
+                    lambda o: o.order_type == 'vacation' 
+                    and o.leave_id
+                    and o.leave_id.state not in ('validate', 'validate1')
+                ):
                     order.leave_id.with_context(_sync_order_leave=True).write({
                         'date_from': order.vacation_date_from,
                         'date_to': order.vacation_date_to,

--- a/l10n_ua_hr_documents/models/hr_order.py
+++ b/l10n_ua_hr_documents/models/hr_order.py
@@ -1,6 +1,5 @@
-from odoo import models, fields, api
+from odoo import models, fields, api, _
 from odoo.exceptions import UserError
-
 
 class HrOrder(models.Model):
     _name = 'hr.order'
@@ -183,7 +182,7 @@ class HrOrder(models.Model):
             order.leave_id.message_post(
                 body=_('Linked vacation order %s was cancelled. Leave state is unchanged.', order.name)
             )
-        return res
+        return True
 
     def unlink(self):
         leaves = self.mapped('leave_id')

--- a/l10n_ua_hr_documents/views/hr_order_views.xml
+++ b/l10n_ua_hr_documents/views/hr_order_views.xml
@@ -49,6 +49,10 @@
                             <field name="date_end" invisible="order_type != 'hiring' or not is_fixed_term"/>
                             <field name="date_dismissal" invisible="order_type != 'dismissal'"/>
                             <field name="dismissal_reason" invisible="order_type != 'dismissal'"/>
+			    <field name="holiday_status_id" invisible="order_type != 'vacation'" required="order_type == 'vacation'" readonly="bool(leave_id)"/>
+			    <field name="vacation_date_from" invisible="order_type != 'vacation'" required="order_type == 'vacation'"/>
+			    <field name="vacation_date_to" invisible="order_type != 'vacation'" required="order_type == 'vacation'"/>
+			    <field name="leave_id" invisible="order_type != 'vacation'" readonly="1"/>
                         </group>
                     </group>
                     <notebook>

--- a/l10n_ua_hr_documents/views/hr_order_views.xml
+++ b/l10n_ua_hr_documents/views/hr_order_views.xml
@@ -49,10 +49,10 @@
                             <field name="date_end" invisible="order_type != 'hiring' or not is_fixed_term"/>
                             <field name="date_dismissal" invisible="order_type != 'dismissal'"/>
                             <field name="dismissal_reason" invisible="order_type != 'dismissal'"/>
-			    <field name="holiday_status_id" invisible="order_type != 'vacation'" required="order_type == 'vacation'" readonly="bool(leave_id)"/>
-			    <field name="vacation_date_from" invisible="order_type != 'vacation'" required="order_type == 'vacation'"/>
-			    <field name="vacation_date_to" invisible="order_type != 'vacation'" required="order_type == 'vacation'"/>
-			    <field name="leave_id" invisible="order_type != 'vacation'" readonly="1"/>
+                            <field name="holiday_status_id" invisible="order_type != 'vacation'" required="order_type == 'vacation'" readonly="bool(leave_id)"/>
+                            <field name="vacation_date_from" invisible="order_type != 'vacation'" required="order_type == 'vacation'"/>
+                            <field name="vacation_date_to" invisible="order_type != 'vacation'" required="order_type == 'vacation'"/>
+                            <field name="leave_id" invisible="order_type != 'vacation'" readonly="1"/>
                         </group>
                     </group>
                     <notebook>

--- a/l10n_ua_hr_holidays/__manifest__.py
+++ b/l10n_ua_hr_holidays/__manifest__.py
@@ -27,6 +27,7 @@ Requires l10n_ua_hr_base module.
         'hr_holidays',
         'resource',
         'l10n_ua_hr_base',
+        'l10n_ua_hr_documents',
     ],
     'data': [
         'security/ir.model.access.csv',

--- a/l10n_ua_hr_holidays/i18n/uk_UA.po
+++ b/l10n_ua_hr_holidays/i18n/uk_UA.po
@@ -1013,3 +1013,14 @@ msgstr "ID е-ТВН"
 #: model:ir.ui.menu,name:l10n_ua_hr_holidays.menu_hr_vacation_calendar
 msgid "Vacation Calendar"
 msgstr "Календар відпусток"
+
+#. module: l10n_ua_hr_holidays
+#: model:ir.model.fields,field_description:l10n_ua_hr_holidays.field_hr_leave_type__create_order
+msgid "Create Order"
+msgstr "Створювати наказ"
+
+#. module: l10n_ua_hr_holidays
+#: model:ir.model.fields,help:l10n_ua_hr_holidays.field_hr_leave_type__create_order
+msgid "Automatically create a vacation order (form П-3) when a leave of this type is created"
+msgstr "Автоматично створювати наказ про відпустку (форма П-3) при створенні відпустки цього типу"
+

--- a/l10n_ua_hr_holidays/i18n/uk_UA.po
+++ b/l10n_ua_hr_holidays/i18n/uk_UA.po
@@ -604,6 +604,11 @@ msgid "Order Number"
 msgstr "Номер наказу"
 
 #. module: l10n_ua_hr_holidays
+#: model:ir.model.fields,field_description:l10n_ua_hr_holidays.field_hr_leave__order_id
+msgid "Leave Order"
+msgstr "Наказ"
+
+#. module: l10n_ua_hr_holidays
 #: model:ir.model.fields.selection,name:l10n_ua_hr_holidays.selection__hr_leave_type__ua_leave_category__other
 msgid "Other"
 msgstr "Інше"

--- a/l10n_ua_hr_holidays/models/hr_leave.py
+++ b/l10n_ua_hr_holidays/models/hr_leave.py
@@ -54,9 +54,18 @@ class HrLeave(models.Model):
     
     vacation_year = fields.Integer(
         string='Vacation Year',
-        help='Year for which vacation is taken'
+        help='Year for which vacation is taken',
+        compute='_compute_vacation_year',
+        store=True,
+        readonly=False,
+        precompute=True,
     )
 
+    @api.depends('request_date_from')
+    def _compute_vacation_year(self):
+        for leave in self:
+            if leave.request_date_from:
+                leave.vacation_year = leave.request_date_from.year
 
     @api.onchange('order_id')
     def _onchange_order_id(self):
@@ -83,8 +92,8 @@ class HrLeave(models.Model):
                 order_vals_list.append({
                     'order_type': 'vacation',
                     'employee_id': vals.get('employee_id'),
-                    'vacation_date_from': vals.get('date_from'),
-                    'vacation_date_to': vals.get('date_to'),
+                    'vacation_date_from': fields.Date.to_date(vals.get('date_from')),
+                    'vacation_date_to': fields.Date.to_date(vals.get('date_to')),
                     # holiday_status_id auto-derived from leave_id (related)
                 })
                 order_indices.append(idx)
@@ -100,12 +109,16 @@ class HrLeave(models.Model):
 
         leaves = super().create(vals_list)
 
-        # Back-link orders → leaves
+        # Back-link orders → leaves + sync dates from already-computed leave
         for leave in leaves:
             if leave.order_id and not leave.order_id.leave_id:
-                leave.order_id.with_context(_sync_order_leave=True).write(
-                    {'leave_id': leave.id}
-                )
+                date_from = leave.date_from.date() if leave.date_from else leave.request_date_from
+                date_to = leave.date_to.date() if leave.date_to else leave.request_date_to
+                leave.order_id.with_context(_sync_order_leave=True).write({
+                    'leave_id': leave.id,
+                    'vacation_date_from': date_from,
+                    'vacation_date_to': date_to,
+                })
         return leaves
 
     def write(self, vals):
@@ -114,9 +127,27 @@ class HrLeave(models.Model):
             if {'date_from', 'date_to'} & vals.keys():
                 for leave in self.filtered(lambda l: l.order_id):
                     leave.order_id.with_context(_sync_order_leave=True).write({
-                        'vacation_date_from': leave.date_from,
-                        'vacation_date_to': leave.date_to,
+                        'vacation_date_from': leave.date_from.date() if leave.date_from else False,
+                        'vacation_date_to': leave.date_to.date() if leave.date_to else False,
                     })
+            if 'holiday_status_id' in vals:
+                for leave in self.filtered(
+                    lambda l: not l.order_id
+                    and l.holiday_status_id
+                    and l.holiday_status_id.create_order
+                    and l.state not in ('validate', 'validate1', 'refuse')
+                ):
+                    order = self.env['hr.order'].with_context(
+                        _creating_order_from_leave=True
+                    ).create({
+                        'order_type': 'vacation',
+                        'employee_id': leave.employee_id.id,
+                        'vacation_date_from': leave.date_from.date() if leave.date_from else False,
+                        'vacation_date_to': leave.date_to.date() if leave.date_to else False,
+                        'subject': 'Про надання відпустки',
+                    })
+                    leave.with_context(_sync_order_leave=True).write({'order_id': order.id})
+                    order.with_context(_sync_order_leave=True).write({'leave_id': leave.id})
         return result
 
     def action_validate(self, *args, **kwargs):

--- a/l10n_ua_hr_holidays/models/hr_leave.py
+++ b/l10n_ua_hr_holidays/models/hr_leave.py
@@ -137,7 +137,8 @@ class HrLeave(models.Model):
 
     def write(self, vals):
         result = super().write(vals)
-        if not self.env.context.get('_sync_order_leave'):
+        # Add a check for _creating_leave_from_order to avoid order duplication
+        if not self.env.context.get('_sync_order_leave') and not self.env.context.get('_creating_leave_from_order'):
             if {'date_from', 'date_to'} & vals.keys():
                 for leave in self.filtered(lambda l: l.order_id):
                     leave.order_id.with_context(_sync_order_leave=True).write({
@@ -166,8 +167,8 @@ class HrLeave(models.Model):
                     order.with_context(_sync_order_leave=True).write({'leave_id': leave.id})
         return result
 
-    def action_validate(self, *args, **kwargs):
-        res = super().action_validate(*args, **kwargs)
+    def _action_validate(self, *args, **kwargs):
+        res = super()._action_validate(*args, **kwargs)
         for leave in self.filtered(lambda l: l.order_id and l.order_id.state == 'draft'):
             leave.order_id.with_context(_sync_order_leave=True).action_confirm()
         return res

--- a/l10n_ua_hr_holidays/models/hr_leave.py
+++ b/l10n_ua_hr_holidays/models/hr_leave.py
@@ -73,6 +73,16 @@ class HrLeave(models.Model):
             self.order_number = self.order_id.name
             self.order_date = self.order_id.date
 
+    def action_view_order(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'hr.order',
+            'res_id': self.order_id.id,
+            'view_mode': 'form',
+            'target': 'current',
+        }
+
     @api.model_create_multi
     def create(self, vals_list):
         # Resolve which leaves should auto-create an order
@@ -118,6 +128,8 @@ class HrLeave(models.Model):
                     'leave_id': leave.id,
                     'vacation_date_from': date_from,
                     'vacation_date_to': date_to,
+                    'department_id': leave.employee_id.department_id.id,
+                    'job_id': leave.employee_id.job_id.id,
                 })
         return leaves
 
@@ -142,6 +154,8 @@ class HrLeave(models.Model):
                     ).create({
                         'order_type': 'vacation',
                         'employee_id': leave.employee_id.id,
+                        'department_id': leave.employee_id.department_id.id,
+                        'job_id': leave.employee_id.job_id.id,
                         'vacation_date_from': leave.date_from.date() if leave.date_from else False,
                         'vacation_date_to': leave.date_to.date() if leave.date_to else False,
                         'subject': 'Про надання відпустки',

--- a/l10n_ua_hr_holidays/models/hr_leave.py
+++ b/l10n_ua_hr_holidays/models/hr_leave.py
@@ -30,7 +30,16 @@ class HrLeave(models.Model):
     
     order_number = fields.Char(string='Order Number')
     order_date = fields.Date(string='Order Date')
-    
+   
+    order_id = fields.Many2one(
+        'hr.order',
+        string='Leave Order',
+        ondelete='set null',
+        copy=False,
+        index=True,
+        domain=[('order_type', '=', 'vacation')],
+    )
+
     remaining_days_before = fields.Float(
         string='Balance Before',
         compute='_compute_remaining_before',
@@ -47,6 +56,91 @@ class HrLeave(models.Model):
         string='Vacation Year',
         help='Year for which vacation is taken'
     )
+
+
+    @api.onchange('order_id')
+    def _onchange_order_id(self):
+        if self.order_id:
+            self.order_number = self.order_id.name
+            self.order_date = self.order_id.date
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Resolve which leaves should auto-create an order
+        type_ids = {v.get('holiday_status_id') for v in vals_list if v.get('holiday_status_id')}
+        types_with_order = set()
+        if type_ids:
+            types_with_order = set(self.env['hr.leave.type'].browse(type_ids).filtered(
+                lambda t: t.create_order
+            ).ids)
+
+        order_vals_list = []
+        order_indices = []
+        for idx, vals in enumerate(vals_list):
+            if (not vals.get('order_id')
+                    and not self.env.context.get('_creating_leave_from_order')
+                    and vals.get('holiday_status_id') in types_with_order):
+                order_vals_list.append({
+                    'order_type': 'vacation',
+                    'employee_id': vals.get('employee_id'),
+                    'vacation_date_from': vals.get('date_from'),
+                    'vacation_date_to': vals.get('date_to'),
+                    # holiday_status_id auto-derived from leave_id (related)
+                })
+                order_indices.append(idx)
+
+        if order_vals_list:
+            orders = self.env['hr.order'].with_context(
+                _creating_order_from_leave=True
+            ).create(order_vals_list)
+            for idx, order in zip(order_indices, orders):
+                vals_list[idx]['order_id'] = order.id
+                vals_list[idx].setdefault('order_number', order.name)
+                vals_list[idx].setdefault('order_date', order.date)
+
+        leaves = super().create(vals_list)
+
+        # Back-link orders → leaves
+        for leave in leaves:
+            if leave.order_id and not leave.order_id.leave_id:
+                leave.order_id.with_context(_sync_order_leave=True).write(
+                    {'leave_id': leave.id}
+                )
+        return leaves
+
+    def write(self, vals):
+        result = super().write(vals)
+        if not self.env.context.get('_sync_order_leave'):
+            if {'date_from', 'date_to'} & vals.keys():
+                for leave in self.filtered(lambda l: l.order_id):
+                    leave.order_id.with_context(_sync_order_leave=True).write({
+                        'vacation_date_from': leave.date_from,
+                        'vacation_date_to': leave.date_to,
+                    })
+        return result
+
+    def action_validate(self, *args, **kwargs):
+        res = super().action_validate(*args, **kwargs)
+        for leave in self.filtered(lambda l: l.order_id and l.order_id.state == 'draft'):
+            leave.order_id.with_context(_sync_order_leave=True).action_confirm()
+        return res
+
+    def action_refuse(self, *args, **kwargs):
+        res = super().action_refuse(*args, **kwargs)
+        for leave in self.filtered(lambda l: l.order_id and l.order_id.state != 'cancelled'):
+            leave.order_id.with_context(_sync_order_leave=True).write({'state': 'cancelled'})
+        return res
+
+    def unlink(self):
+        orders_to_delete = self.filtered(
+            lambda l: l.order_id
+            and l.state != 'validate'
+            and l.order_id.state == 'draft'
+        ).mapped('order_id')
+        res = super().unlink()
+        if orders_to_delete:
+            orders_to_delete.with_context(_sync_order_leave=True).unlink()
+        return res
 
     @api.constrains('employee_id', 'holiday_status_id', 'date_from')
     def _check_minimum_experience(self):

--- a/l10n_ua_hr_holidays/models/hr_leave_type.py
+++ b/l10n_ua_hr_holidays/models/hr_leave_type.py
@@ -74,3 +74,8 @@ class HrLeaveType(models.Model):
         string='Max Additional Days',
         help='Maximum additional days for this leave type (e.g., 35 for hazardous, 7 for irregular)'
     )
+    create_order = fields.Boolean(
+        string='Create Order',
+        default=False,
+        help='Automatically create a vacation order (form П-3) when a leave of this type is created',
+    )

--- a/l10n_ua_hr_holidays/tests/__init__.py
+++ b/l10n_ua_hr_holidays/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_hr_leave
 from . import test_hr_leave_type
 from . import test_hr_vacation_balance
 from . import test_hr_sick_leave
+from . import test_hr_leave_order_sync

--- a/l10n_ua_hr_holidays/tests/test_hr_leave_order_sync.py
+++ b/l10n_ua_hr_holidays/tests/test_hr_leave_order_sync.py
@@ -1,0 +1,105 @@
+from odoo.tests import common
+from datetime import date
+from odoo.tests import tagged
+
+@tagged('post_install', '-at_install')
+class TestHrLeaveOrderSync(common.TransactionCase):
+    
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        
+        # Create a test employee
+        cls.employee = cls.env['hr.employee'].create({
+            'name': 'Test Employee',
+        })
+        
+        # Create a leave type that generates orders
+        cls.leave_type = cls.env['hr.leave.type'].create({
+            'name': 'Annual Basic Leave',
+            'time_type': 'leave',
+            'requires_allocation': 'yes',
+            'create_order': True,
+            'is_paid': True,
+        })
+
+        # Allocate leave days to the employee so validation passes
+        cls.allocation = cls.env['hr.leave.allocation'].create({
+            'name': 'Test Leave Allocation',
+            'employee_id': cls.employee.id,
+            'holiday_status_id': cls.leave_type.id,
+            'number_of_days': 100,
+        })
+        cls.allocation.action_approve()
+        if cls.allocation.state == 'validate1':
+            cls.allocation.action_validate()
+
+    def test_bidirectional_create_from_order(self):
+        """ Test: Creating an order creates exactly 1 leave and does not duplicate orders. """
+        order = self.env['hr.order'].create({
+            'order_type': 'vacation',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'vacation_date_from': date(2027, 8, 1),
+            'vacation_date_to': date(2027, 8, 5),
+            'date': date(2027, 8, 1),
+            'subject': 'Vacation',
+        })
+        
+        # Check that there is only one order
+        orders_count = self.env['hr.order'].search_count([('employee_id', '=', self.employee.id)])
+        self.assertEqual(orders_count, 1, "Order creation generated a duplicate.")
+        
+        # Check that there is only one leave
+        leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)])
+        self.assertEqual(len(leaves), 1, "Exactly one leave must be created.")
+        
+        # Check bidirectional relationship
+        self.assertEqual(order.leave_id.id, leaves.id)
+        self.assertEqual(leaves.order_id.id, order.id)
+
+    def test_bidirectional_create_from_leave(self):
+        """ Test: Creating a leave creates exactly 1 order. """
+        leave = self.env['hr.leave'].create({
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': date(2027, 9, 1),
+            'request_date_to': date(2027, 9, 5),
+        })
+        
+        orders = self.env['hr.order'].search([('employee_id', '=', self.employee.id)])
+        self.assertEqual(len(orders), 1, "Exactly one order must be created.")
+        self.assertEqual(leave.order_id.id, orders.id)
+
+    def test_state_sync_validate(self):
+        """ Test: Validating a leave confirms the order. """
+        leave = self.env['hr.leave'].create({
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': date(2027, 10, 1),
+            'request_date_to': date(2027, 10, 5),
+        })
+        
+        order = leave.order_id
+        self.assertEqual(order.state, 'draft')
+        
+        # Call the private hook or standard action_approve
+        leave._action_validate()
+        
+        self.assertEqual(order.state, 'confirmed', "Order state did not change to confirmed after leave validation.")
+
+    def test_cascade_delete(self):
+        """ Test: Unlinking a draft leave also unlinks the draft order. """
+        leave = self.env['hr.leave'].create({
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': date(2027, 11, 1),
+            'request_date_to': date(2027, 11, 5),
+        })
+        
+        order = leave.order_id
+        self.assertTrue(order.exists())
+        
+        leave.unlink()
+        
+        self.assertFalse(order.exists(), "The order was not cascade deleted with the leave.")

--- a/l10n_ua_hr_holidays/views/hr_leave_type_views.xml
+++ b/l10n_ua_hr_holidays/views/hr_leave_type_views.xml
@@ -23,6 +23,7 @@
                     <group>
                         <field name="is_paid"/>
                         <field name="payment_source" invisible="not is_paid"/>
+       		    	<field name="create_order"/>
                     </group>
                 </group>
             </xpath>

--- a/l10n_ua_hr_holidays/views/hr_leave_views.xml
+++ b/l10n_ua_hr_holidays/views/hr_leave_views.xml
@@ -22,9 +22,9 @@
                         <field name="remaining_days_after"/>
                     </group>
                     <group>
-    			<field name="order_id"/>
-                        <field name="order_number"/>
-                        <field name="order_date"/>
+			<field name="order_id"/>
+			<field name="order_number" invisible="bool(order_id)"/>
+			<field name="order_date" invisible="bool(order_id)"/>
                     </group>
                 </group>
             </xpath>

--- a/l10n_ua_hr_holidays/views/hr_leave_views.xml
+++ b/l10n_ua_hr_holidays/views/hr_leave_views.xml
@@ -6,6 +6,7 @@
         <field name="model">hr.leave</field>
         <field name="inherit_id" ref="hr_holidays.hr_leave_view_form"/>
         <field name="arch" type="xml">
+
             <xpath expr="//sheet" position="inside">
                 <group string="Ukrainian Specifics" name="ua_details">
                     <group>
@@ -23,7 +24,6 @@
                     </group>
                     <group>
 			<field name="order_id"/>
-			<field name="order_number" invisible="bool(order_id)"/>
 			<field name="order_date" invisible="bool(order_id)"/>
                     </group>
                 </group>

--- a/l10n_ua_hr_holidays/views/hr_leave_views.xml
+++ b/l10n_ua_hr_holidays/views/hr_leave_views.xml
@@ -22,6 +22,7 @@
                         <field name="remaining_days_after"/>
                     </group>
                     <group>
+    			<field name="order_id"/>
                         <field name="order_number"/>
                         <field name="order_date"/>
                     </group>


### PR DESCRIPTION

## Двостороння прив'язка відпустки та наказу на відпустку

### Контекст та проблеми

В Odoo-локалізації для України форма відпустки (`hr.leave`) містила лише текстові поля `order_number` та `order_date`, які заповнювались вручну без зв'язку з реальним записом наказу (`hr.order`). Це породжувало низку проблем:

- **Відсутність структурного зв'язку** між відпусткою та наказом — дані дублювались і могли розходитись
- **Шаблон П-3** містив статичні заглушки (`____`) замість реальних дат, виду та тривалості відпустки
- **Форма П2, розділ IV** відображала порожні рядки — реальні дані відпусток не виводились
- Стани відпустки та наказу не були синхронізовані — підтвердження чи відхилення відпустки не впливало на стан наказу

Також враховані коментарі в issue #36 

---

### Реалізовані зміни

#### 1. Чекбокс `Створювати наказ` на типі відпустки (`hr.leave.type`)

Додано поле `create_order` (за замовчуванням `False`). Автоматичне створення наказу відбувається лише для тих типів відпусток, де цей прапорець увімкнений. Це забезпечує зворотну сумісність — існуючі відпустки без зв'язку залишаються незмінними.

#### 2. Двосторонній зв'язок між `hr.leave` та `hr.order`

Реалізовано відповідно до рекомендацій з [[issue #36](https://github.com/NadozirnySvyatoslav/l10n_ua/issues/36#issuecomment-4298024040)](https://github.com/NadozirnySvyatoslav/l10n_ua/issues/36#issuecomment-4298024040):

- **`hr.order`** отримав поля `vacation_date_from`, `vacation_date_to`, `leave_id` (`ondelete='set null'`) та `holiday_status_id` як related-поле від `leave_id.holiday_status_id` з `store=True`, `readonly=False` — усуває дублювання без втрати можливості ручного введення *(рек. №5)*
- **`hr.leave`** отримав поле `order_id` (`ondelete='set null'`) з domain `[('order_type', '=', 'vacation')]`
- При створенні відпустки з типом `create_order=True` — автоматично створюється vacation-наказ з підрозділом і посадою співробітника
- При створенні vacation-наказу вручну — автоматично створюється відповідна відпустка
- Записи створюються пакетно одним SQL INSERT для продуктивності *(рек. №4)*

#### 3. Синхронізація дат

Зміна дат в одному записі автоматично оновлює пов'язаний запис. Синхронізація в напрямку наказ → відпустка захищена перевіркою стану: не виконується якщо відпустка вже у стані `validate`/`validate1`.

#### 4. Синхронізація станів *(рек. №2)*

| Подія на відпустці | Дія на наказі |
|---|---|
| `action_validate()` | `action_confirm()` (якщо наказ у `draft`) |
| `action_refuse()` | `state = 'cancelled'` |
| Скасування наказу | Стан відпустки не змінюється, повідомлення у chatter |

#### 5. Каскадне видалення *(рек. №3)*

- Видалення draft-відпустки → видаляється пов'язаний draft-наказ
- Видалення підтвердженої відпустки → наказ залишається, `leave_id` стає `NULL`
- Видалення наказу → `order_id` у відпустці стає `NULL`, повідомлення у chatter

#### 6. Шаблон наказу П-3

Динамічно підставляються: вид відпустки (`holiday_status_id.name`), тривалість у календарних днях (`leave_id.calendar_days`), дата початку та закінчення. При відсутності зв'язаної відпустки — відображаються заглушки для ручного заповнення.

#### 7. Форма П2, розділ IV

Замість порожніх рядків — динамічний цикл по підтверджених відпустках співробітника. Підстава відображається з пов'язаного наказу (`order_id.name`, `order_id.date`) або з ручних полів (`order_number`, `order_date`) як fallback для старих записів.

#### 8. Рік відпустки

Поле `vacation_year` на `hr.leave` тепер автоматично заповнюється з дати початку відпустки (`request_date_from.year`) та залишається редагованим для перехідних відпусток.

---

### Як перевірити через UI

**Підготовка:**
1. Оновити модулі `l10n_ua_hr_holidays`, `l10n_ua_hr_documents`, `l10n_ua_hr_base`
2. HR → Конфігурація → Типи відпусток → "Щорічна основна відпустка" → увімкнути **Створювати наказ** → зберегти

**Тест A — автоматичне створення наказу при створенні відпустки:**
1. HR → Відпустки → Нова відпустка → тип "Щорічна основна", вибрати співробітника, дати → зберегти
2. ✅ У полі **Leave Order** з'явився наказ; підрозділ і посада в наказі заповнені автоматично; дати співпадають

**Тест B — автоматичне створення відпустки при створенні наказу:**
1. HR → Накази → Новий наказ → тип Vacation, вибрати співробітника, тип відпустки, дати → зберегти
2. ✅ Поле **Leave Record** у наказі містить відпустку; відпустка містить посилання на наказ

**Тест C — зміна типу відпустки після збереження:**
1. Відкрити відпустку без наказу → змінити тип на "Щорічна основна" (з `create_order=True`) → зберегти
2. ✅ Наказ створено автоматично

**Тест D — синхронізація станів:**
1. Підтвердити відпустку → ✅ пов'язаний наказ переходить у `Confirmed`
2. Відхилити іншу відпустку → ✅ наказ переходить у `Cancelled`
3. Скасувати наказ вручну → ✅ стан відпустки не змінюється, у chatter відпустки є повідомлення

**Тест E — шаблон П-3:**
1. Відкрити vacation-наказ з пов'язаною відпусткою → Завантажити шаблон → П-3
2. ✅ Вид відпустки, тривалість та дати підставлені автоматично

**Тест F — форма П2:**
1. HR → Звіти → Особова картка П2 для співробітника з підтвердженими відпустками
2. ✅ Розділ IV містить рядки з реальними даними: вид, рік, дати, "наказ № XXX від ДД.ММ.РРРР"

**Тест G — зворотна сумісність:**
1. Відкрити будь-яку стару відпустку без `order_id` → ✅ відкривається без помилок, поле наказу порожнє, наказ не створюється автоматично