### PR TITLE
Added Employee Number (Табельний номер)

### DIFF
--- a/l10n_ua_hr_base/data/ir_sequence_data.xml
+++ b/l10n_ua_hr_base/data/ir_sequence_data.xml
@@ -2,6 +2,15 @@
 <odoo>
     <data noupdate="1">
 
+        <!-- Personnel Number Sequence (Табельний номер) -->
+        <record id="seq_hr_employee_number" model="ir.sequence">
+            <field name="name">Employee Personnel Number</field>
+            <field name="code">hr.employee.number</field>
+            <field name="prefix">%(year)s-</field>
+            <field name="padding">4</field>
+            <field name="company_id" eval="False"/>
+        </record>
+
         <!-- HR Order Sequences -->
         
         <record id="seq_hr_order_hiring" model="ir.sequence">

--- a/l10n_ua_hr_base/demo/hr_demo_data.xml
+++ b/l10n_ua_hr_base/demo/hr_demo_data.xml
@@ -82,7 +82,7 @@
             <field name="company_id" ref="demo_ua_company"/>
             <field name="department_id" ref="demo_department_admin"/>
             <field name="job_id" ref="demo_job_director"/>
-            <field name="barcode">001</field>
+            <field name="employee_number">001</field>
             <field name="rnokpp">1234567899</field>
             <field name="document_type">id_card</field>
             <field name="passport_id">123456789</field>
@@ -111,7 +111,7 @@
             <field name="company_id" ref="demo_ua_company"/>
             <field name="department_id" ref="demo_department_hr"/>
             <field name="job_id" ref="demo_job_hr_manager"/>
-            <field name="barcode">002</field>
+            <field name="employee_number">002</field>
             <field name="rnokpp">2345678902</field>
             <field name="document_type">id_card</field>
             <field name="passport_id">234567890</field>
@@ -137,7 +137,7 @@
             <field name="company_id" ref="demo_ua_company"/>
             <field name="department_id" ref="demo_department_accounting"/>
             <field name="job_id" ref="demo_job_accountant"/>
-            <field name="barcode">003</field>
+            <field name="employee_number">003</field>
             <field name="rnokpp">3456789014</field>
             <field name="document_type">id_card</field>
             <field name="passport_id">345678901</field>
@@ -163,7 +163,7 @@
             <field name="company_id" ref="demo_ua_company"/>
             <field name="department_id" ref="demo_department_it"/>
             <field name="job_id" ref="demo_job_it_admin"/>
-            <field name="barcode">004</field>
+            <field name="employee_number">004</field>
             <field name="rnokpp">4567890120</field>
             <field name="document_type">id_card</field>
             <field name="passport_id">456789012</field>
@@ -194,7 +194,7 @@
             <field name="company_id" ref="demo_ua_company"/>
             <field name="department_id" ref="demo_department_it"/>
             <field name="job_id" ref="demo_job_developer"/>
-            <field name="barcode">005</field>
+            <field name="employee_number">005</field>
             <field name="rnokpp">5678901233</field>
             <field name="document_type">id_card</field>
             <field name="passport_id">567890123</field>
@@ -225,7 +225,7 @@
             <field name="company_id" ref="demo_ua_company"/>
             <field name="department_id" ref="demo_department_hr"/>
             <field name="job_id" ref="demo_job_hr_specialist"/>
-            <field name="barcode">006</field>
+            <field name="employee_number">006</field>
             <field name="rnokpp">6789012344</field>
             <field name="document_type">id_card</field>
             <field name="passport_id">678901234</field>

--- a/l10n_ua_hr_base/i18n/uk_UA.po
+++ b/l10n_ua_hr_base/i18n/uk_UA.po
@@ -1987,8 +1987,14 @@ msgstr "Стаж роботи"
 
 #. module: l10n_ua_hr_base
 #: model:ir.model.fields,field_description:l10n_ua_hr_base.field_hr_employee__employee_number
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_base.view_employee_form_inherit_ua
 msgid "Personnel Number"
 msgstr "Табельний номер"
+
+#. module: l10n_ua_hr_base
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_base.view_employee_form_inherit_ua
+msgid "Generate"
+msgstr "Згенерувати"
 
 #. module: l10n_ua_hr_base
 #: model:ir.model.fields,help:l10n_ua_hr_base.field_hr_employee__employee_number

--- a/l10n_ua_hr_base/i18n/uk_UA.po
+++ b/l10n_ua_hr_base/i18n/uk_UA.po
@@ -1984,3 +1984,18 @@ msgstr "Умови праці"
 msgid "Work Experience"
 msgstr "Стаж роботи"
 
+
+#. module: l10n_ua_hr_base
+#: model:ir.model.fields,field_description:l10n_ua_hr_base.field_hr_employee__employee_number
+msgid "Personnel Number"
+msgstr "Табельний номер"
+
+#. module: l10n_ua_hr_base
+#: model:ir.model.fields,help:l10n_ua_hr_base.field_hr_employee__employee_number
+msgid "Personnel number of the employee according to Ukrainian legislation (Табельний номер)"
+msgstr "Табельний номер працівника згідно з українським законодавством"
+
+#. module: l10n_ua_hr_base
+#: model:ir.sequence,name:l10n_ua_hr_base.seq_hr_employee_number
+msgid "Employee Personnel Number"
+msgstr "Табельний номер співробітника"

--- a/l10n_ua_hr_base/models/hr_employee.py
+++ b/l10n_ua_hr_base/models/hr_employee.py
@@ -8,6 +8,17 @@ class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
     # === Personal Documents ===
+    employee_number = fields.Char(
+        string='Personnel Number',
+        copy=False,
+        help='Personnel number of the employee according to Ukrainian legislation (Табельний номер)')
+
+    def action_generate_employee_number(self):
+        """Generate next personnel number from the sequence."""
+        for employee in self:
+            if not employee.employee_number:
+                employee.employee_number = self.env['ir.sequence'].next_by_code('hr.employee.number')
+
     # RNOKPP is Ukrainian-specific, different from Odoo's identification_id
     rnokpp = fields.Char(
         string='RNOKPP (IPN)', size=10,

--- a/l10n_ua_hr_base/report/hr_employee_p2_report.xml
+++ b/l10n_ua_hr_base/report/hr_employee_p2_report.xml
@@ -52,7 +52,7 @@
                 <table style="width: 100%; border-collapse: collapse; margin-bottom: 10px; font-size: 10pt;">
                     <tr>
                         <td style="border: 1px solid #000; padding: 3px; width: 25%;">Табельний номер</td>
-                        <td style="border: 1px solid #000; padding: 3px; width: 25%;"><t t-esc="employee.barcode or ''"/></td>
+                        <td style="border: 1px solid #000; padding: 3px; width: 25%;"><t t-esc="employee.employee_number or ''"/></td>
                         <td style="border: 1px solid #000; padding: 3px; width: 25%;">РНОКПП</td>
                         <td style="border: 1px solid #000; padding: 3px; width: 25%;"><t t-esc="employee.rnokpp or ''"/></td>
                     </tr>

--- a/l10n_ua_hr_base/views/hr_employee_views.xml
+++ b/l10n_ua_hr_base/views/hr_employee_views.xml
@@ -38,16 +38,6 @@
                 <page string="UA: Персональне" name="ua_personal" groups="hr.group_hr_user">
                     <group>
                         <group string="Документи">
-                            <label for="employee_number"/>
-                            <div class="o_row">
-                                <field name="employee_number" placeholder="e.g. 2026-0001"/>
-                                <button string="Generate" 
-                                        class="btn btn-link" 
-                                        type="object" 
-                                        name="action_generate_employee_number" 
-                                        invisible="employee_number"
-                                        groups="hr.group_hr_user"/>
-                            </div>
                             <field name="rnokpp" placeholder="1234567890"/>
                             <field name="document_type"/>
                             <field name="passport_series" invisible="document_type != 'passport'"/>
@@ -140,6 +130,23 @@
                     </group>
                 </page>
             </xpath>
+
+            <!-- Move Personnel Number to standard Work Information tab -->
+            <xpath expr="//page[@name='public']//div[@id='o_work_employee_main']" position="inside">
+                <group string="Work" name="work_personnel_number">
+                    <label for="employee_number" string="Personnel Number"/>
+                    <div class="o_row">
+                        <field name="employee_number" placeholder="e.g. 2026-0001"/>
+                        <button string="Generate" 
+                                class="btn btn-link" 
+                                type="object" 
+                                name="action_generate_employee_number" 
+                                invisible="employee_number"
+                                groups="hr.group_hr_user"/>
+                    </div>
+                </group>
+            </xpath>
+
         </field>
     </record>
 

--- a/l10n_ua_hr_base/views/hr_employee_views.xml
+++ b/l10n_ua_hr_base/views/hr_employee_views.xml
@@ -132,7 +132,7 @@
             </xpath>
 
             <!-- Move Personnel Number to standard Work Information tab -->
-            <xpath expr="//page[@name='public']" position="inside">
+            <xpath expr="//page[@name='work_information']" position="inside">
                 <group string="Work" name="work_personnel_number">
                     <label for="employee_number" string="Personnel Number"/>
                     <div class="o_row">

--- a/l10n_ua_hr_base/views/hr_employee_views.xml
+++ b/l10n_ua_hr_base/views/hr_employee_views.xml
@@ -132,7 +132,7 @@
             </xpath>
 
             <!-- Move Personnel Number to standard Work Information tab -->
-            <xpath expr="//page[@name='public']//div[@id='o_work_employee_main']" position="inside">
+            <xpath expr="//page[@name='public']" position="inside">
                 <group string="Work" name="work_personnel_number">
                     <label for="employee_number" string="Personnel Number"/>
                     <div class="o_row">

--- a/l10n_ua_hr_base/views/hr_employee_views.xml
+++ b/l10n_ua_hr_base/views/hr_employee_views.xml
@@ -38,6 +38,16 @@
                 <page string="UA: Персональне" name="ua_personal" groups="hr.group_hr_user">
                     <group>
                         <group string="Документи">
+                            <label for="employee_number"/>
+                            <div class="o_row">
+                                <field name="employee_number" placeholder="e.g. 2026-0001"/>
+                                <button string="Generate" 
+                                        class="btn btn-link" 
+                                        type="object" 
+                                        name="action_generate_employee_number" 
+                                        invisible="employee_number"
+                                        groups="hr.group_hr_user"/>
+                            </div>
                             <field name="rnokpp" placeholder="1234567890"/>
                             <field name="document_type"/>
                             <field name="passport_series" invisible="document_type != 'passport'"/>

--- a/l10n_ua_hr_base/views/hr_employee_views.xml
+++ b/l10n_ua_hr_base/views/hr_employee_views.xml
@@ -132,19 +132,17 @@
             </xpath>
 
             <!-- Move Personnel Number to standard Work Information tab -->
-            <xpath expr="//page[@name='work_information']" position="inside">
-                <group string="Work" name="work_personnel_number">
-                    <label for="employee_number" string="Personnel Number"/>
-                    <div class="o_row">
-                        <field name="employee_number" placeholder="e.g. 2026-0001"/>
-                        <button string="Generate" 
-                                class="btn btn-link" 
-                                type="object" 
-                                name="action_generate_employee_number" 
-                                invisible="employee_number"
-                                groups="hr.group_hr_user"/>
-                    </div>
-                </group>
+            <xpath expr="//page[@name='work_information']//field[@name='parent_id']" position="after">
+                <label for="employee_number" string="Personnel Number"/>
+                <div class="o_row">
+                    <field name="employee_number" placeholder="e.g. 2026-0001"/>
+                    <button string="Generate" 
+                            class="btn btn-link" 
+                            type="object" 
+                            name="action_generate_employee_number" 
+                            invisible="employee_number"
+                            groups="hr.group_hr_user"/>
+                </div>
             </xpath>
 
         </field>

--- a/l10n_ua_hr_documents/data/hr_order_template_data.xml
+++ b/l10n_ua_hr_documents/data/hr_order_template_data.xml
@@ -61,7 +61,7 @@
             </tr>
             <tr>
                 <td style="padding: 5px;">Табельний номер:</td>
-                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.barcode or '____________'" t-if="employee"/><t t-else="">____________</t></td>
+                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.employee_number or '____________'" t-if="employee"/><t t-else="">____________</t></td>
             </tr>
             <tr>
                 <td style="padding: 5px;">Структурний підрозділ:</td>
@@ -164,7 +164,7 @@
             </tr>
             <tr>
                 <td style="padding: 5px;">Табельний номер:</td>
-                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.barcode or '____________'" t-if="employee"/><t t-else="">____________</t></td>
+                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.employee_number or '____________'" t-if="employee"/><t t-else="">____________</t></td>
             </tr>
             <tr>
                 <td style="padding: 5px;">Структурний підрозділ:</td>
@@ -269,7 +269,7 @@
             </tr>
             <tr>
                 <td style="padding: 5px;">Табельний номер:</td>
-                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.barcode or '____________'" t-if="employee"/><t t-else="">____________</t></td>
+                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.employee_number or '____________'" t-if="employee"/><t t-else="">____________</t></td>
             </tr>
         </table>
 
@@ -376,7 +376,7 @@
             </tr>
             <tr>
                 <td style="padding: 5px;">Табельний номер:</td>
-                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.barcode or '____________'" t-if="employee"/><t t-else="">____________</t></td>
+                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.employee_number or '____________'" t-if="employee"/><t t-else="">____________</t></td>
             </tr>
             <tr>
                 <td style="padding: 5px;">Структурний підрозділ:</td>
@@ -593,7 +593,7 @@
             </tr>
             <tr>
                 <td style="padding: 5px;">Табельний номер:</td>
-                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.barcode or '____________'" t-if="employee"/><t t-else="">____________</t></td>
+                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.employee_number or '____________'" t-if="employee"/><t t-else="">____________</t></td>
             </tr>
             <tr>
                 <td style="padding: 5px;">Структурний підрозділ:</td>
@@ -714,7 +714,7 @@
             </tr>
             <tr>
                 <td style="padding: 5px;">Табельний номер:</td>
-                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.barcode or '____________'" t-if="employee"/><t t-else="">____________</t></td>
+                <td style="padding: 5px; border-bottom: 1px solid #000;"><t t-esc="employee.employee_number or '____________'" t-if="employee"/><t t-else="">____________</t></td>
             </tr>
             <tr>
                 <td style="padding: 5px;">Структурний підрозділ:</td>

--- a/l10n_ua_hr_salary/report/hr_payslip_report.xml
+++ b/l10n_ua_hr_salary/report/hr_payslip_report.xml
@@ -38,7 +38,7 @@
                         <td style="border: 1px solid #000; padding: 5px; width: 25%;"><strong>Працівник:</strong></td>
                         <td style="border: 1px solid #000; padding: 5px; width: 25%;"><t t-esc="payslip.employee_id.name"/></td>
                         <td style="border: 1px solid #000; padding: 5px; width: 25%;"><strong>Табельний №:</strong></td>
-                        <td style="border: 1px solid #000; padding: 5px; width: 25%;"><t t-esc="payslip.employee_id.barcode or ''"/></td>
+                        <td style="border: 1px solid #000; padding: 5px; width: 25%;"><t t-esc="payslip.employee_id.employee_number or ''"/></td>
                     </tr>
                     <tr>
                         <td style="border: 1px solid #000; padding: 5px;"><strong>Підрозділ:</strong></td>


### PR DESCRIPTION
## Контекст

В українському законодавстві **«Табельний номер»** є обов'язковим реквізитом для кадрових документів (накази, особова картка П-2) та розрахункових листків. У
      попередній версії локалізації для збереження та виведення цього номера використовувалося стандартне поле Odoo — `barcode` (в інтерфейсі відоме як *Badge ID* або
      *Штрихкод*).

Використання `barcode` як табельного номера створювало кілька суттєвих проблем:
1. **Функціональний конфлікт:** Поле `barcode` в Odoo має своє цільове призначення (наприклад, для систем контролю доступу або сканування бейджів). Його
      "перевикористання" унеможливлювало застосування штрихкодів за їхнім прямим призначенням.
2. **Незручність інтерфейсу:** Користувачам (кадровикам) доводилося шукати поле «Badge ID» у вкладці «Налаштування HR», щоб ввести табельний номер, що було неочевидно.

 Також дивись issue #45 

## Виправлення

Для вирішення цієї проблеми було реалізовано окремий механізм обліку табельних номерів:

* **Нове поле `employee_number`:** До моделі `hr.employee` додано виділене поле «Табельний номер» (`employee_number`), яке повністю відділене від функціоналу штрихкодів Odoo.
* **Автоматична генерація (Sequence):** Створено нову послідовність (`ir.sequence` з кодом `hr.employee.number`) для автоматичної генерації номерів у зручному форматі (наприклад, `2026-0001`).
* **Вкладка "Робоча":** Поле `employee_number` інтегровано у стандартну вкладку Odoo **"Робоча інформація" (Work Information)** у секцію "Work" (відразу після поля Менеджер). Поруч додано кнопку **"Згенерувати" (Generate)**, яка дозволяє присвоїти наступний вільний номер в один клік, зберігаючи при цьому можливість ручного вводу.
* **Оновлення друкованих форм та звітів:** Усі локалізовані шаблони переведено на використання нового поля замість `barcode`:
* Особова картка працівника (Типова форма № П-2).
* Усі шаблони кадрових наказів (прийом на роботу, звільнення, переведення, відпустки тощо).
* Розрахункові листки (Payslips).
* **Оновлення демо-даних:** Демонстраційних співробітників (`hr_demo_data.xml`) оновлено — тепер вони створюються з коректно заповненим полем `employee_number`.
* **Локалізація:** Додано та оновлено українські переклади у файлі `uk_UA.po` для нових полів, описів та кнопок ("Personnel Number", "Generate" тощо).