### PR TITLE
feat: Додано кнопку масового перерахунку балансів відпусток

### DIFF
--- a/l10n_ua_hr_holidays/i18n/uk_UA.po
+++ b/l10n_ua_hr_holidays/i18n/uk_UA.po
@@ -1065,3 +1065,20 @@ msgstr "Створювати наказ"
 #: model:ir.model.fields,help:l10n_ua_hr_holidays.field_hr_leave_type__create_order
 msgid "Automatically create a vacation order (form П-3) when a leave of this type is created"
 msgstr "Автоматично створювати наказ про відпустку (форма П-3) при створенні відпустки цього типу"
+
+#. module: l10n_ua_hr_holidays
+#: model_terms:ir.ui.view,arch_db:l10n_ua_hr_holidays.hr_vacation_balance_view_tree
+msgid "Recalculate"
+msgstr "Перерахувати"
+
+#. module: l10n_ua_hr_holidays
+#. odoo-python
+#: code:addons/l10n_ua_hr_holidays/models/hr_vacation_balance.py:0
+msgid "Recalculation Complete"
+msgstr "Перерахунок завершено"
+
+#. module: l10n_ua_hr_holidays
+#. odoo-python
+#: code:addons/l10n_ua_hr_holidays/models/hr_vacation_balance.py:0
+msgid "Vacation balances for %s have been updated for all active employees."
+msgstr "Залишки відпусток на %s рік оновлені для всіх активних співробітників."

--- a/l10n_ua_hr_holidays/models/hr_vacation_balance.py
+++ b/l10n_ua_hr_holidays/models/hr_vacation_balance.py
@@ -252,3 +252,26 @@ class HrVacationBalance(models.Model):
                 'sticky': False,
             }
         }
+
+    def action_recalculate_all(self):
+        """
+        Recalculate or generate vacation balances for the current year
+        for all active employees.
+        """
+        current_year = fields.Date.today().year
+        self.generate_balances(year=current_year)
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': 'Recalculation Complete',
+                'message': f'Vacation balances for {current_year} have been updated for all active employees.',
+                'type': 'success',
+                'sticky': False,
+                'next': {
+                    'type': 'ir.actions.client',
+                    'tag': 'reload',
+                }
+            }
+        }

--- a/l10n_ua_hr_holidays/models/hr_vacation_balance.py
+++ b/l10n_ua_hr_holidays/models/hr_vacation_balance.py
@@ -246,8 +246,8 @@ class HrVacationBalance(models.Model):
             'type': 'ir.actions.client',
             'tag': 'display_notification',
             'params': {
-                'title': 'Vacation Compensation',
-                'message': f'Compensation for {self.remaining_days} unused days: {compensation:.2f} UAH',
+                'title': _('Vacation Compensation'),
+                'message': _('Compensation for %(days)s unused days: %(amount).2f UAH', days=self.remaining_days, amount=compensation),
                 'type': 'success',
                 'sticky': False,
             }
@@ -265,8 +265,8 @@ class HrVacationBalance(models.Model):
             'type': 'ir.actions.client',
             'tag': 'display_notification',
             'params': {
-                'title': 'Recalculation Complete',
-                'message': f'Vacation balances for {current_year} have been updated for all active employees.',
+                'title': _('Recalculation Complete'),
+                'message': _('Vacation balances for %s have been updated for all active employees.', current_year),
                 'type': 'success',
                 'sticky': False,
                 'next': {

--- a/l10n_ua_hr_holidays/views/hr_vacation_balance_views.xml
+++ b/l10n_ua_hr_holidays/views/hr_vacation_balance_views.xml
@@ -47,7 +47,7 @@
                             string="Recalculate"
                             type="object"
                             class="btn-secondary"
-			    display="always"
+                            display="always"
                             groups="hr_holidays.group_hr_holidays_manager"/>
                 </header>
                 <field name="employee_id"/>

--- a/l10n_ua_hr_holidays/views/hr_vacation_balance_views.xml
+++ b/l10n_ua_hr_holidays/views/hr_vacation_balance_views.xml
@@ -42,6 +42,14 @@
         <field name="model">hr.vacation.balance</field>
         <field name="arch" type="xml">
             <list string="Vacation Balances">
+                <header>
+                    <button name="action_recalculate_all"
+                            string="Recalculate"
+                            type="object"
+                            class="btn-secondary"
+			    display="always"
+                            groups="hr_holidays.group_hr_holidays_manager"/>
+                </header>
                 <field name="employee_id"/>
                 <field name="leave_type_id"/>
                 <field name="year"/>


### PR DESCRIPTION

### 📝 Опис проблеми 
До цього моменту в системі не було зручного інструменту для масового оновлення або створення залишків відпусток для всіх активних співробітників безпосередньо з інтерфейсу користувача. Це ускладнювало актуалізацію даних для HR-менеджерів на початку нового періоду або після масових змін.

### 🛠 Що було зроблено 
1. **Бізнес-логіка (`models/hr_vacation_balance.py`)**:
   - Додано метод `action_recalculate_all`, який викликає існуючий механізм `generate_balances` для поточного року.
   - Налаштовано повернення `ir.actions.client` для показу спливаючого сповіщення про успішний перерахунок та миттєвого перезавантаження сторінки (`tag: reload`) для миттєвого відображення нових даних.

2. **Інтерфейс (`views/hr_vacation_balance_views.xml`)**:
   - У `list` (tree) view додано секцію `<header>` з кнопкою **"Перерахувати"**. 
   - Кнопку захищено правами доступу — вона відображається лише для користувачів із групою менеджера відпусток (`hr_holidays.group_hr_holidays_manager`).

3. **Локалізація (`i18n/uk_UA.po`)**:
   - Додано відповідні українські переклади для назви нової кнопки та тексту спливаючих сповіщень про завершення перерахунку.

### 🧪 Як перевірити 
1. Оновіть модуль `l10n_ua_hr_holidays` (Upgrade).
2. Перейдіть у меню **Відпустки -> Залишки відпусток**.
3. Зверху над таблицею записів натисніть кнопку **"Перерахувати"**.
4. Переконайтеся, що з'явилося зелене сповіщення про успішний перерахунок.
5. Переконайтеся, що сторінка автоматично оновилася, і в списку з'явилися/оновилися актуальні баланси співробітників.
