### PR TITLE
fix(l10n_ua_marketplace_base): add stat-button methods on product.product for Odoo 19 view validation

### DIFF
--- a/l10n_ua_marketplace_base/models/__init__.py
+++ b/l10n_ua_marketplace_base/models/__init__.py
@@ -4,4 +4,5 @@ from . import marketplace_category
 from . import marketplace_order
 from . import marketplace_status_mapping
 from . import product_template
+from . import product_product
 from . import res_partner

--- a/l10n_ua_marketplace_base/models/product_product.py
+++ b/l10n_ua_marketplace_base/models/product_product.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    def action_view_marketplace_items(self):
+        """Delegate to template — required because product.product_normal_form_view
+        inherits product_template_form_view in primary mode (Odoo 19), so the
+        stat-button on the template form is also rendered on variant form.
+        Strict view validation requires the method to exist on product.product."""
+        return self.product_tmpl_id.action_view_marketplace_items()
+
+    def action_add_to_marketplace(self):
+        """Same as action_view_marketplace_items — delegate to template."""
+        return self.product_tmpl_id.action_add_to_marketplace()


### PR DESCRIPTION
Refs #44 (частина 1 — marketplace bug)

## Проблема

В Odoo 19 \`product.product_normal_form_view\` оголошено як \`inherit_id = product.product_template_form_view\` з \`mode = primary\`. Це означає що форма варіанта повністю успадковує template-форму, включно зі stat-button-ами.

Strict view validation (\`validate=\"1\"\`) тепер вимагає, щоб методи всіх кнопок з template-форми існували і на \`product.product\`. У \`l10n_ua_marketplace_base\` методи \`action_view_marketplace_items\` і \`action_add_to_marketplace\` визначені тільки на \`product.template\`.

Симптом: коли в БД встановлено будь-який модуль, що \`inherit\`-ить \`product.product_normal_form_view\` (у нашому випадку \`super_ecom_multi_website_selection\`), при його upgrade/install Odoo падає:
\`\`\`
ParseError: while parsing .../product_product_view.xml
action_view_marketplace_items недійсна дія на product.product
\`\`\`

## Фікс

Створено \`l10n_ua_marketplace_base/models/product_product.py\` з двома методами що делегують до template:

\`\`\`python
class ProductProduct(models.Model):
    _inherit = 'product.product'

    def action_view_marketplace_items(self):
        return self.product_tmpl_id.action_view_marketplace_items()

    def action_add_to_marketplace(self):
        return self.product_tmpl_id.action_add_to_marketplace()
\`\`\`

## Перевірка

- Install \`l10n_ua_marketplace_base\` без помилок ✅
- Через odoo shell:
  \`\`\`
  hasattr(env['product.product'], 'action_view_marketplace_items'): True
  hasattr(env['product.product'], 'action_add_to_marketplace'): True
  Returns dict: True, keys: ['name', 'type', 'res_model', 'view_mode', 'domain', 'context']
  \`\`\`