### PR TITLE
fix(hr): auto-populate director and employee names in signature blocks

### DIFF
--- a/l10n_ua_hr_documents/data/hr_order_template_data.xml
+++ b/l10n_ua_hr_documents/data/hr_order_template_data.xml
@@ -97,7 +97,7 @@
             <tr>
                 <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
                 <td style="width: 10%;"></td>
-                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
+                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"><t t-esc="employee.name if employee else ''"/></td>
                 <td style="width: 10%;"></td>
                 <td style="width: 20%; text-align: center; border-bottom: 1px solid #000;"></td>
             </tr>
@@ -202,7 +202,7 @@
             <tr>
                 <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
                 <td style="width: 10%;"></td>
-                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
+                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"><t t-esc="employee.name if employee else ''"/></td>
                 <td style="width: 10%;"></td>
                 <td style="width: 20%; text-align: center; border-bottom: 1px solid #000;"></td>
             </tr>
@@ -309,7 +309,7 @@
             <tr>
                 <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
                 <td style="width: 10%;"></td>
-                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
+                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"><t t-esc="employee.name if employee else ''"/></td>
                 <td style="width: 10%;"></td>
                 <td style="width: 20%; text-align: center; border-bottom: 1px solid #000;"></td>
             </tr>
@@ -440,7 +440,7 @@
             <tr>
                 <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
                 <td style="width: 10%;"></td>
-                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
+                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"><t t-esc="employee.name if employee else ''"/></td>
                 <td style="width: 10%;"></td>
                 <td style="width: 20%; text-align: center; border-bottom: 1px solid #000;"></td>
             </tr>
@@ -663,7 +663,7 @@
             <tr>
                 <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
                 <td style="width: 10%;"></td>
-                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
+                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"><t t-esc="employee.name if employee else ''"/></td>
                 <td style="width: 10%;"></td>
                 <td style="width: 20%; text-align: center; border-bottom: 1px solid #000;"></td>
             </tr>
@@ -799,7 +799,7 @@
             <tr>
                 <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
                 <td style="width: 10%;"></td>
-                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"></td>
+                <td style="width: 30%; text-align: center; border-bottom: 1px solid #000;"><t t-esc="employee.name if employee else ''"/></td>
                 <td style="width: 10%;"></td>
                 <td style="width: 20%; text-align: center; border-bottom: 1px solid #000;"></td>
             </tr>

--- a/l10n_ua_hr_documents/report/hr_order_report.xml
+++ b/l10n_ua_hr_documents/report/hr_order_report.xml
@@ -77,7 +77,7 @@
                             <tr>
                                 <td style="width: 40%;">Керівник</td>
                                 <td style="width: 30%; border-bottom: 1px solid #000;"></td>
-                                <td style="width: 30%; border-bottom: 1px solid #000;"></td>
+                                <td style="width: 30%; border-bottom: 1px solid #000;"><span t-field="order.company_id.director_id.name"/></td>
                             </tr>
                             <tr>
                                 <td></td>

--- a/l10n_ua_hr_documents/wizard/hr_order_template_wizard.py
+++ b/l10n_ua_hr_documents/wizard/hr_order_template_wizard.py
@@ -53,8 +53,10 @@ class HrOrderTemplateWizard(models.TransientModel):
         employee = order.employee_id
         company = order.company_id
 
-        # Get director from company (hr_responsible_id or first manager)
-        director = company.hr_responsible_id if hasattr(company, 'hr_responsible_id') and company.hr_responsible_id else False
+        # Signatories from company settings (l10n_ua_hr_base)
+        director = company.director_id or False
+        accountant = company.accountant_id or False
+        hr_manager = company.hr_manager_id or False
 
         return {
             'o': order,
@@ -64,6 +66,8 @@ class HrOrderTemplateWizard(models.TransientModel):
             'department': order.department_id or (employee.department_id if employee else False),
             'job': order.job_id or (employee.job_id if employee else False),
             'director': director,
+            'accountant': accountant,
+            'hr_manager': hr_manager,
             'format_date': self._format_date,
             'format_date_ua': self._format_date_ua,
             'month_name': self._get_month_name,

--- a/l10n_ua_hr_documents_certificates/data/hr_certificate_type_data.xml
+++ b/l10n_ua_hr_documents_certificates/data/hr_certificate_type_data.xml
@@ -94,7 +94,7 @@
             </tr>
             <tr>
                 <td style="width: 50%;">Головний бухгалтер</td>
-                <td style="width: 50%; text-align: right;">________________</td>
+                <td style="width: 50%; text-align: right;">________________ <t t-esc="accountant.name if accountant else ''"/></td>
             </tr>
         </table>
     </div>
@@ -150,7 +150,7 @@
             </tr>
             <tr>
                 <td style="width: 50%;">Головний бухгалтер</td>
-                <td style="width: 50%; text-align: right;">________________</td>
+                <td style="width: 50%; text-align: right;">________________ <t t-esc="accountant.name if accountant else ''"/></td>
             </tr>
         </table>
     </div>
@@ -258,7 +258,7 @@
             </tr>
             <tr>
                 <td style="width: 50%;">Головний бухгалтер</td>
-                <td style="width: 50%; text-align: right;">________________</td>
+                <td style="width: 50%; text-align: right;">________________ <t t-esc="accountant.name if accountant else ''"/></td>
             </tr>
         </table>
     </div>

--- a/l10n_ua_hr_documents_certificates/models/hr_certificate.py
+++ b/l10n_ua_hr_documents_certificates/models/hr_certificate.py
@@ -215,6 +215,11 @@ class HrCertificate(models.Model):
             director = company.director_id
             director_position = director.job_id.name if director.job_id else 'Директор'
 
+        # Chief accountant from company settings
+        accountant = False
+        if hasattr(company, 'accountant_id') and company.accountant_id:
+            accountant = company.accountant_id
+
         # Get hire date from contract (if hr_contract module is installed)
         hire_date = False
         contract = False
@@ -236,6 +241,7 @@ class HrCertificate(models.Model):
             'company': company,
             'director': director,
             'director_position': director_position,
+            'accountant': accountant,
             'contract': contract,
             'hire_date': hire_date,
             'work_experience': work_experience,

--- a/l10n_ua_hr_holidays/report/hr_leave_report.xml
+++ b/l10n_ua_hr_holidays/report/hr_leave_report.xml
@@ -72,7 +72,7 @@
                         <tr>
                             <td style="width: 50%;">Директор</td>
                             <td style="width: 50%; text-align: right;">
-                                _____________ / _____________ /
+                                _____________ / <t t-esc="leave.employee_id.company_id.director_id.name or '_____________'"/> /
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
## Контекст

У шаблонах HR-документів (накази, довідки, звіти про відпустки) рядки для підпису директора та працівника не заповнювались автоматично — у PDF замість ПІБ виводились прочерки. Корінь проблеми — wizard рендеру шукав на `res.company` неіснуюче поле `hr_responsible_id`, тоді як у `l10n_ua_hr_base` визначені `director_id`, `accountant_id`, `hr_manager_id`. Додатково деякі шаблони взагалі не мали `t-esc` у відповідних комірках.

## Що змінено

**Основний фікс**
- `l10n_ua_hr_documents/wizard/hr_order_template_wizard.py` — `company.hr_responsible_id` → `company.director_id`; у render-контекст додано `accountant` і `hr_manager`.

**Шаблони наказів**
- `l10n_ua_hr_documents/data/hr_order_template_data.xml` — у 6 шаблонах (hiring, dismissal, transfer, vacation, sick_leave, business_trip) у блоці «З наказом ознайомлений(а)» комірка під «(П.І.Б.)» тепер виводить `employee.name`.

**Довідки**
- `l10n_ua_hr_documents_certificates/models/hr_certificate.py` — у render-контекст додано `accountant` (з `company.accountant_id`).
- `l10n_ua_hr_documents_certificates/data/hr_certificate_type_data.xml` — у трьох довідках (про зарплату, про доходи, для банку) поряд з підписом «Головний бухгалтер» виводиться `accountant.name`.

**Звіти**
- `l10n_ua_hr_holidays/report/hr_leave_report.xml` — у блоці підпису директора виводиться `leave.employee_id.company_id.director_id.name`.
- `l10n_ua_hr_documents/report/hr_order_report.xml` — у fallback-формі наказу (коли `order.content` порожній) у комірці під підписом керівника виводиться ПІБ директора компанії.

## План тестування

- [ ] Оновити модулі `l10n_ua_hr_documents`, `l10n_ua_hr_documents_certificates`, `l10n_ua_hr_holidays`.
- [ ] У налаштуваннях компанії заповнити поля **Директор** та **Головний бухгалтер**.
- [ ] Створити кожен з 6 типів наказів через wizard, відрендерити PDF — переконатись, що ПІБ директора з'являється в підписному блоці, а ПІБ працівника — в блоці «З наказом ознайомлений(а)».
- [ ] Створити довідку про ЗП / про доходи / для банку — перевірити, що ПІБ директора і головбуха підставляються автоматично.
- [ ] Створити та підтвердити відпустку — у звіті бачити ПІБ директора.
- [ ] Створити наказ без застосування шаблону (порожній `content`) — у fallback-звіті має з'явитись ПІБ директора.
- [ ] Граничний кейс: компанія без `director_id` / `accountant_id` — звіти рендеряться без помилки (виводиться прочерк).

https://claude.ai/code/session_01EDZYzJCRkXGiEstTY3rJBJ