### PR TITLE
fix(assets): code-review follow-ups переоцінки ОЗ (#101-#111)

### DIFF
--- a/l10n_ua_assets/models/account_asset.py
+++ b/l10n_ua_assets/models/account_asset.py
@@ -213,10 +213,9 @@ class L10nUaAsset(models.Model):
 
     def action_view_revaluations(self):
         self.ensure_one()
-        Line = self.env['l10n_ua.asset.revaluation.line']
-        revaluation_ids = Line.search([
-            ('asset_id', '=', self.id),
-        ]).mapped('revaluation_id').ids
+        revaluation_ids = self.revaluation_line_ids.filtered(
+            lambda l: l.state == 'confirmed'
+        ).mapped('revaluation_id').ids
         return {
             'name': _('Переоцінки %s') % self.name,
             'type': 'ir.actions.act_window',

--- a/l10n_ua_assets/models/l10n_ua_asset_revaluation.py
+++ b/l10n_ua_assets/models/l10n_ua_asset_revaluation.py
@@ -9,6 +9,7 @@ class L10nUaAssetRevaluation(models.Model):
     _description = 'Переоцінка основних засобів'
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _order = 'date desc, id desc'
+    _check_company_auto = True
 
     name = fields.Char(
         string='Номер',
@@ -56,30 +57,35 @@ class L10nUaAssetRevaluation(models.Model):
         string='Журнал',
         domain="[('type', '=', 'general'), ('company_id', '=', company_id)]",
         help='Бухгалтерський журнал для проводок переоцінки',
+        check_company=True,
     )
     fixed_asset_account_id = fields.Many2one(
         'account.account',
         string='Рахунок ОЗ (10)',
         domain="[('company_ids', 'in', company_id)]",
         help='Рахунок первісної вартості ОЗ (за замовч. 10)',
+        check_company=True,
     )
     accumulated_depreciation_account_id = fields.Many2one(
         'account.account',
         string='Рахунок зносу (131)',
         domain="[('company_ids', 'in', company_id)]",
         help='Рахунок накопиченого зносу (за замовч. 131)',
+        check_company=True,
     )
     revaluation_surplus_account_id = fields.Many2one(
         'account.account',
         string='Дооцінка (411)',
         domain="[('company_ids', 'in', company_id)]",
         help='Капітал у дооцінках (за замовч. 411)',
+        check_company=True,
     )
     impairment_loss_account_id = fields.Many2one(
         'account.account',
         string='Уцінка (975)',
         domain="[('company_ids', 'in', company_id)]",
         help='Витрати на уцінку ОЗ (за замовч. 975)',
+        check_company=True,
     )
     other_income_account_id = fields.Many2one(
         'account.account',
@@ -87,12 +93,14 @@ class L10nUaAssetRevaluation(models.Model):
         domain="[('company_ids', 'in', company_id)]",
         help='Інші операційні доходи — використовується при дооцінці '
              'після попередньої уцінки (П(С)БО 7 п.20)',
+        check_company=True,
     )
     move_id = fields.Many2one(
         'account.move',
         string='Бухгалтерська проводка',
         readonly=True,
         copy=False,
+        check_company=True,
     )
 
     # --- Підсумки ---
@@ -150,33 +158,61 @@ class L10nUaAssetRevaluation(models.Model):
     def action_confirm(self):
         """Підтвердити переоцінку: створити коригувальні рядки амортизації,
         оновити первісну вартість ОЗ, створити account.move.
+
+        Бере row-level lock на документ, щоб уникнути race-condition
+        при double-click або паралельних викликах.
         """
+        # Acquire FOR UPDATE on this revaluation row so a concurrent
+        # confirm call serialises behind us instead of producing
+        # duplicate moves / adjustment rows.
+        if self.ids:
+            self.env.cr.execute(
+                'SELECT id FROM l10n_ua_asset_revaluation '
+                'WHERE id IN %s FOR UPDATE',
+                (tuple(self.ids),),
+            )
         for rec in self:
             if rec.state != 'draft':
                 raise UserError(_('Переоцінку можна підтвердити лише з чернетки.'))
             if not rec.line_ids:
                 raise UserError(_('Додайте хоча б один ОЗ до переоцінки.'))
+            # Server-side check that all referenced assets are still in
+            # an operable state — the form-level domain is only a UI hint.
+            bad_assets = rec.line_ids.filtered(
+                lambda l: l.asset_id.state not in ('open', 'paused')
+            ).mapped('asset_id')
+            if bad_assets:
+                raise UserError(_(
+                    'Не можна переоцінити ОЗ у стані відмінному від '
+                    '«В експлуатації» або «Призупинено»: %s'
+                ) % ', '.join(bad_assets.mapped('display_name')))
+            # Refresh snapshot from live values to avoid drift when
+            # depreciation was posted between draft creation and confirm.
+            rec.line_ids._refresh_snapshot()
             rec._validate_accounts()
             rec.line_ids._apply_to_assets()
             rec._create_account_move()
             rec.state = 'confirmed'
-            rec.message_post(body=_('Переоцінку підтверджено.'))
         return True
 
     def action_cancel(self):
-        """Скасувати переоцінку: повернути активам попередні значення,
-        видалити коригувальні рядки амортизації, скасувати account.move.
+        """Скасувати переоцінку: спершу скасувати проводку, потім
+        повернути активам попередні значення, видалити коригувальні
+        рядки амортизації.
+
+        Move cancel/draft може впасти (закритий період, узгоджені
+        рядки) — тому робимо це ПЕРЕД мутацією активів, щоб не
+        залишити неузгоджений стан.
         """
         for rec in self:
             if rec.state != 'confirmed':
                 raise UserError(_('Скасувати можна лише підтверджену переоцінку.'))
-            rec.line_ids._revert_from_assets()
             if rec.move_id:
                 if rec.move_id.state == 'posted':
                     rec.move_id.button_draft()
                 rec.move_id.button_cancel()
+            rec.line_ids._revert_from_assets()
             rec.state = 'cancelled'
-            rec.message_post(body=_('Переоцінку скасовано.'))
         return True
 
     def action_draft(self):
@@ -374,6 +410,7 @@ class L10nUaAssetRevaluationLine(models.Model):
     _name = 'l10n_ua.asset.revaluation.line'
     _description = 'Рядок переоцінки ОЗ'
     _order = 'revaluation_id, id'
+    _check_company_auto = True
 
     revaluation_id = fields.Many2one(
         'l10n_ua.asset.revaluation',
@@ -381,11 +418,17 @@ class L10nUaAssetRevaluationLine(models.Model):
         required=True,
         ondelete='cascade',
     )
+    company_id = fields.Many2one(
+        related='revaluation_id.company_id',
+        store=True,
+    )
     asset_id = fields.Many2one(
         'l10n_ua.asset',
         string='Основний засіб',
         required=True,
-        domain="[('state', 'in', ['open', 'paused'])]",
+        domain="[('state', 'in', ['open', 'paused']),"
+               " ('company_id', '=?', company_id)]",
+        check_company=True,
     )
 
     # Снапшот «до» (заморожується при створенні рядка)
@@ -497,40 +540,71 @@ class L10nUaAssetRevaluationLine(models.Model):
                  'original_value_before', 'accumulated_before')
     def _compute_revaluation(self):
         for line in self:
+            currency = line.currency_id or line.revaluation_id.currency_id
             book_before = line.book_value_before
-            if book_before > 0:
+            # Use currency.is_zero rather than raw `> 0` so a tiny rounding
+            # residue (e.g. 0.001) can't survive the guard and blow up index.
+            if currency and not currency.is_zero(book_before) and book_before > 0:
                 index = line.fair_value / book_before
             else:
                 index = 0.0
             line.revaluation_index = round(index, 6)
-            line.original_value_after = round(line.original_value_before * index, 2)
-            line.accumulated_after = round(line.accumulated_before * index, 2)
+            if currency:
+                line.original_value_after = currency.round(
+                    line.original_value_before * index)
+                line.accumulated_after = currency.round(
+                    line.accumulated_before * index)
+            else:
+                line.original_value_after = round(
+                    line.original_value_before * index, 2)
+                line.accumulated_after = round(
+                    line.accumulated_before * index, 2)
             line.book_value_after = line.original_value_after - line.accumulated_after
             line.original_change = line.original_value_after - line.original_value_before
             line.accumulated_change = line.accumulated_after - line.accumulated_before
             line.revaluation_amount = line.book_value_after - book_before
 
-            currency = line.currency_id or line.revaluation_id.currency_id
             if currency and currency.is_zero(line.revaluation_amount):
                 line.revaluation_type = 'none'
             elif line.revaluation_amount > 0:
                 line.revaluation_type = 'increase'
-            elif line.revaluation_amount < 0:
-                line.revaluation_type = 'decrease'
             else:
-                line.revaluation_type = 'none'
+                line.revaluation_type = 'decrease'
 
     @api.constrains('fair_value', 'book_value_before')
     def _check_fair_value(self):
         for line in self:
+            currency = line.currency_id or line.revaluation_id.currency_id
             if line.fair_value < 0:
                 raise ValidationError(_(
                     'Справедлива вартість не може бути від\'ємною.'
                 ))
-            if line.book_value_before <= 0:
+            # Use currency.compare_amounts so a tiny rounding tail
+            # (0.001) doesn't masquerade as positive book value.
+            if currency and currency.compare_amounts(line.book_value_before, 0) <= 0:
                 raise ValidationError(_(
                     'Залишкова вартість ОЗ "%s" повинна бути більше нуля для переоцінки.'
                 ) % line.asset_id.display_name)
+
+    def _refresh_snapshot(self):
+        """Оновити снапшот original_value_before / accumulated_before з
+        поточних значень асета. Викликається в action_confirm щоб уникнути
+        drift коли амортизація постилась між draft-creation і confirm.
+
+        Зберігається fair_value (вже введена користувачем) — індекс
+        і всі after-поля перерахуються через api.depends.
+        """
+        for line in self:
+            asset = line.asset_id
+            if not asset:
+                continue
+            updates = {}
+            if line.original_value_before != asset.original_value:
+                updates['original_value_before'] = asset.original_value
+            if line.accumulated_before != asset.accumulated_depreciation:
+                updates['accumulated_before'] = asset.accumulated_depreciation
+            if updates:
+                line.write(updates)
 
     def _apply_to_assets(self):
         """Застосувати переоцінку до ОЗ: створити коригувальний рядок амортизації

--- a/l10n_ua_assets/tests/test_revaluation.py
+++ b/l10n_ua_assets/tests/test_revaluation.py
@@ -451,3 +451,55 @@ class TestAssetRevaluation(TransactionCase):
         self.assertEqual(rev.state, 'draft')
         self.assertEqual(len(rev.line_ids), 1)
         self.assertEqual(rev.line_ids.asset_id, asset)
+
+    def test_confirm_refreshes_stale_snapshot(self):
+        """#101: якщо депреціація постилась між draft і confirm —
+        snapshot оновлюється з live значень асета.
+        """
+        asset = self._create_asset(original_value=100000)
+        asset.action_commission()
+        self._post_depreciation(asset, 20000)
+        # Створюємо draft зі snapshot accumulated=20000
+        rev = self.env['l10n_ua.asset.revaluation'].create({
+            **self._common_revaluation_vals(),
+            'line_ids': [(0, 0, {
+                'asset_id': asset.id,
+                'original_value_before': asset.original_value,
+                'accumulated_before': asset.accumulated_depreciation,
+                'fair_value': 100000,
+            })],
+        })
+        # Між створенням і confirm — пройшла ще одна амортизація
+        self._post_depreciation(asset, 5000, date_=date(2025, 5, 31))
+        # asset.accumulated_depreciation тепер 25000
+        self.assertAlmostEqual(asset.accumulated_depreciation, 25000, places=2)
+        # Підтверджуємо — snapshot має оновитися
+        rev.action_confirm()
+        line = rev.line_ids
+        self.assertAlmostEqual(line.accumulated_before, 25000, places=2)
+        # book_value_before = 100000 - 25000 = 75000
+        # index = 100000 / 75000 = 1.333...
+        # new_original = 100000 * 1.333... = 133333.33
+        # new_accumulated = 25000 * 1.333... = 33333.33
+        self.assertAlmostEqual(asset.original_value, 133333.33, places=2)
+        self.assertAlmostEqual(asset.book_value, 100000, places=0)
+
+    def test_confirm_rejects_written_off_asset(self):
+        """#110: action_confirm перевіряє стан асета."""
+        asset = self._create_asset()
+        asset.action_commission()
+        self._post_depreciation(asset, 10000)
+        rev = self.env['l10n_ua.asset.revaluation'].create({
+            **self._common_revaluation_vals(),
+            'line_ids': [(0, 0, {
+                'asset_id': asset.id,
+                'original_value_before': asset.original_value,
+                'accumulated_before': asset.accumulated_depreciation,
+                'fair_value': asset.book_value + 1000,
+            })],
+        })
+        # Списати асет
+        asset.action_write_off()
+        # Тепер confirm має впасти
+        with self.assertRaises(UserError):
+            rev.action_confirm()

--- a/l10n_ua_assets/views/l10n_ua_asset_revaluation_views.xml
+++ b/l10n_ua_assets/views/l10n_ua_asset_revaluation_views.xml
@@ -30,7 +30,9 @@
                         <button name="action_view_move" type="object"
                                 class="oe_stat_button" icon="fa-pencil-square-o"
                                 invisible="not move_id">
-                            <field name="move_id" widget="statinfo" string="Проводка"/>
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Проводка</span>
+                            </div>
                         </button>
                     </div>
                     <div class="oe_title">
@@ -138,7 +140,7 @@
                         domain="[('state', '=', 'cancelled')]"/>
                 <separator/>
                 <filter string="Цей рік" name="filter_this_year"
-                        domain="[('date', '&gt;=', (context_today().replace(month=1, day=1)).strftime('%Y-%m-%d'))]"/>
+                        domain="[('date', '&gt;=', context_today().replace(month=1, day=1))]"/>
 
                 <group>
                     <filter string="Стан" name="groupby_state" domain="[]"


### PR DESCRIPTION
## Опис

Зведений PR по 11 знахідках code-review PR #100 (переоцінка ОЗ).

Closes #101, #102, #103, #104, #105, #106, #107, #108, #109, #110, #111

## Фікси

| # | Issue | Підхід |
|---|-------|--------|
| #101 | stale snapshot vs live accumulated | `_refresh_snapshot()` на початку `action_confirm` оновлює `original_value_before` / `accumulated_before` з live значень асета |
| #102 | multi-company safety | `_check_company_auto=True` + `check_company=True` на всіх M2o; `company_id` related на line; domain `asset_id` фільтрує по company |
| #103 | action_confirm idempotency | `SELECT FOR UPDATE` на старті action_confirm |
| #104 | action_cancel ordering | move.button_draft/cancel ВПЕРЕД, потім `_revert_from_assets` |
| #105 | currency.round() | `currency.round(x)` замість `round(x, 2)` для Monetary |
| #106 | float comparison | `currency.is_zero` / `compare_amounts` замість raw `> 0` / `<= 0` |
| #107 | statinfo on Many2one | замінено на `<div class="o_stat_info">` label-only |
| #108 | strftime у domain | прибрано `.strftime('%Y-%m-%d')` у фільтрі «Цей рік» |
| #109 | count vs view mismatch | `action_view_revaluations` фільтрує по `state='confirmed'` |
| #110 | asset state check | server-side перевірка `asset.state in ('open', 'paused')` у `action_confirm` |
| #111 | double chatter | прибрано ручний `message_post` (tracking на state вже постить) |

## Нові тести

- `test_confirm_refreshes_stale_snapshot` (#101)
- `test_confirm_rejects_written_off_asset` (#110)

## Тестування

69 тестів проходить, 0 failed:
- 18 revaluation (16 + 2 нових)
- 11 modernization
- 15 inventory
- 25 існуючих (asset, mnma)

## Test plan

- [x] `odoo -u l10n_ua_assets --test-enable` — 0 failed
- [ ] Кліки в UI: smart-button «Проводка» — без числа (labeled)
- [ ] Створити draft, постити амортизацію, confirm — перевірити що snapshot оновлюється
- [ ] Створити draft, списати асет, confirm — UserError

🤖 Generated with [Claude Code](https://claude.com/claude-code)