### PR TITLE
feat(hr_vacation_reserve): резерв відпусток (П(С)БО 26) — закриває #84

### DIFF
--- a/l10n_ua_hr_vacation_reserve/__init__.py
+++ b/l10n_ua_hr_vacation_reserve/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ua_hr_vacation_reserve/__manifest__.py
+++ b/l10n_ua_hr_vacation_reserve/__manifest__.py
@@ -1,0 +1,43 @@
+{
+    'name': 'Ukraine - HR Vacation Reserve',
+    'version': '19.0.1.0.0',
+    'category': 'Human Resources/Localization',
+    'summary': 'Резерв відпусток: автоматичне нарахування проводок (П(С)БО 26)',
+    'description': """
+Ukraine HR Vacation Reserve Module
+==================================
+
+Automatic accrual of vacation reserve provisions per П(С)БО 26
+«Виплати працівникам» and ст. 23.4 ПКУ.
+
+* Monthly cron-driven accrual of vacation reserve per active employee
+* Accrual entries: Дт 23 / 91 / 92 / 93 (expense per function) / Кт 471
+* Reversal entries on actual vacation payment: Дт 471 / Кт 661
+* Configurable expense accounts per hr.job and hr.employee
+* Configurable journal, periodicity, and default 471/661 accounts on company
+* History of monthly reserve documents with line per employee
+
+Requires l10n_ua_hr_holidays, l10n_ua_hr_salary, and account modules.
+    """,
+    'author': 'Svyatoslav Nadozirny',
+    'website': 'https://many2one.online',
+    'license': 'LGPL-3',
+    'depends': [
+        'account',
+        'l10n_ua_hr_holidays',
+        'l10n_ua_hr_salary',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'data/ir_sequence_data.xml',
+        'data/ir_cron_data.xml',
+        'views/res_company_views.xml',
+        'views/hr_job_views.xml',
+        'views/hr_employee_views.xml',
+        'views/hr_vacation_reserve_views.xml',
+        'views/menu_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/l10n_ua_hr_vacation_reserve/data/ir_cron_data.xml
+++ b/l10n_ua_hr_vacation_reserve/data/ir_cron_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="cron_accrue_vacation_reserve" model="ir.cron">
+            <field name="name">HR: нарахування резерву відпусток</field>
+            <field name="model_id" ref="model_hr_vacation_reserve"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_accrue_vacation_reserve()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">months</field>
+            <field name="active" eval="False"/>
+        </record>
+
+    </data>
+</odoo>

--- a/l10n_ua_hr_vacation_reserve/data/ir_sequence_data.xml
+++ b/l10n_ua_hr_vacation_reserve/data/ir_sequence_data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="seq_hr_vacation_reserve" model="ir.sequence">
+        <field name="name">Резерв відпусток</field>
+        <field name="code">hr.vacation.reserve</field>
+        <field name="prefix">РВ-</field>
+        <field name="padding">4</field>
+    </record>
+
+</odoo>

--- a/l10n_ua_hr_vacation_reserve/models/__init__.py
+++ b/l10n_ua_hr_vacation_reserve/models/__init__.py
@@ -1,0 +1,5 @@
+from . import res_company
+from . import hr_job
+from . import hr_employee
+from . import hr_vacation_reserve
+from . import hr_payslip

--- a/l10n_ua_hr_vacation_reserve/models/hr_employee.py
+++ b/l10n_ua_hr_vacation_reserve/models/hr_employee.py
@@ -1,0 +1,25 @@
+from odoo import fields, models
+
+
+class HrEmployee(models.Model):
+    _inherit = 'hr.employee'
+
+    vacation_reserve_expense_account_id = fields.Many2one(
+        'account.account',
+        string='Рахунок витрат на резерв',
+        domain="[('company_ids', 'in', company_id)]",
+        check_company=True,
+        help='Override для конкретного працівника. Якщо не задано — '
+             'береться з hr.job, потім з компанії.',
+    )
+
+    def _get_vacation_reserve_expense_account(self):
+        """Розрахувати рахунок витрат за пріоритетом:
+        employee → job → company default.
+        """
+        self.ensure_one()
+        if self.vacation_reserve_expense_account_id:
+            return self.vacation_reserve_expense_account_id
+        if self.job_id and self.job_id.vacation_reserve_expense_account_id:
+            return self.job_id.vacation_reserve_expense_account_id
+        return self.company_id.vacation_reserve_default_expense_account_id

--- a/l10n_ua_hr_vacation_reserve/models/hr_job.py
+++ b/l10n_ua_hr_vacation_reserve/models/hr_job.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class HrJob(models.Model):
+    _inherit = 'hr.job'
+
+    vacation_reserve_expense_account_id = fields.Many2one(
+        'account.account',
+        string='Рахунок витрат на резерв',
+        domain="[('company_ids', 'in', company_id)]",
+        check_company=True,
+        help='Рахунок витрат, на який списується резерв відпусток для цієї '
+             'посади (23 — виробництво, 91 — адмін, 92 — збут, 93 — інші '
+             'операційні). Якщо не задано — береться з компанії.',
+    )

--- a/l10n_ua_hr_vacation_reserve/models/hr_payslip.py
+++ b/l10n_ua_hr_vacation_reserve/models/hr_payslip.py
@@ -1,0 +1,89 @@
+"""Hook на нарахування відпускних — обернена проводка Дт 471 / Кт 661."""
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class HrPayslip(models.Model):
+    _inherit = 'hr.payslip'
+
+    vacation_reserve_reversal_move_id = fields.Many2one(
+        'account.move',
+        string='Проводка реверсу резерву',
+        readonly=True,
+        copy=False,
+        help='Обернена проводка Дт 471 / Кт 661 на суму нарахованих відпускних',
+    )
+
+    def action_payslip_done(self):
+        res = super().action_payslip_done()
+        for payslip in self:
+            payslip._create_vacation_reserve_reversal()
+        return res
+
+    def action_payslip_cancel(self):
+        # Cancel the reversal move first if it exists
+        for payslip in self:
+            move = payslip.vacation_reserve_reversal_move_id
+            if move:
+                if move.state == 'posted':
+                    move.button_draft()
+                move.button_cancel()
+        return super().action_payslip_cancel()
+
+    def _get_vacation_accrual_amount(self):
+        """Сума нарахованих відпускних у поточному payslip."""
+        self.ensure_one()
+        if not hasattr(self, 'accrual_ids'):
+            return 0.0
+        vacation_accruals = self.accrual_ids.filtered(
+            lambda a: a.accrual_type_id.category == 'vacation'
+        )
+        return sum(vacation_accruals.mapped('amount'))
+
+    def _create_vacation_reserve_reversal(self):
+        """Створити обернену проводку Дт 471 / Кт 661 на суму відпускних.
+
+        Якщо компанія не має налаштованого резерву — мовчки пропустити.
+        Якщо проводку вже створено для цього payslip — пропустити.
+        """
+        self.ensure_one()
+        if self.vacation_reserve_reversal_move_id:
+            return
+        amount = self._get_vacation_accrual_amount()
+        if not amount:
+            return
+        company = self.company_id
+        reserve_acc = company.vacation_reserve_account_id
+        payable_acc = company.vacation_payable_account_id
+        journal = company.vacation_reserve_journal_id
+        if not reserve_acc or not payable_acc or not journal:
+            # Reserve not configured — skip silently
+            return
+        currency = company.currency_id
+        amount = currency.round(amount) if currency else round(amount, 2)
+        if not amount:
+            return
+        ref = _('Виплата відпускних %s (%s)') % (self.number or '', self.employee_id.name)
+        move = self.env['account.move'].create({
+            'journal_id': journal.id,
+            'date': fields.Date.context_today(self),
+            'ref': ref,
+            'company_id': company.id,
+            'line_ids': [
+                (0, 0, {
+                    'account_id': reserve_acc.id,
+                    'name': ref,
+                    'debit': amount,
+                    'credit': 0.0,
+                }),
+                (0, 0, {
+                    'account_id': payable_acc.id,
+                    'name': ref,
+                    'debit': 0.0,
+                    'credit': amount,
+                }),
+            ],
+        })
+        move.action_post()
+        self.vacation_reserve_reversal_move_id = move

--- a/l10n_ua_hr_vacation_reserve/models/hr_vacation_reserve.py
+++ b/l10n_ua_hr_vacation_reserve/models/hr_vacation_reserve.py
@@ -1,0 +1,424 @@
+"""Резерв відпусток — П(С)БО 26 «Виплати працівникам», ст. 23.4 ПКУ."""
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class HrVacationReserve(models.Model):
+    _name = 'hr.vacation.reserve'
+    _description = 'Резерв відпусток (документ)'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _order = 'period_end desc, id desc'
+    _check_company_auto = True
+
+    name = fields.Char(
+        string='Номер',
+        default=lambda self: _('Нова'),
+        readonly=True,
+        copy=False,
+        tracking=True,
+    )
+    period_start = fields.Date(
+        string='Початок періоду',
+        required=True,
+        tracking=True,
+    )
+    period_end = fields.Date(
+        string='Кінець періоду',
+        required=True,
+        tracking=True,
+    )
+    state = fields.Selection(
+        selection=[
+            ('draft', 'Чернетка'),
+            ('confirmed', 'Підтверджено'),
+            ('cancelled', 'Скасовано'),
+        ],
+        default='draft',
+        tracking=True,
+        copy=False,
+    )
+
+    # --- Бухгалтерія ---
+    journal_id = fields.Many2one(
+        'account.journal',
+        string='Журнал',
+        domain="[('type', '=', 'general'), ('company_id', '=', company_id)]",
+        check_company=True,
+    )
+    reserve_account_id = fields.Many2one(
+        'account.account',
+        string='Рахунок резерву (471)',
+        domain="[('company_ids', 'in', company_id)]",
+        check_company=True,
+    )
+    move_id = fields.Many2one(
+        'account.move',
+        string='Бухгалтерська проводка',
+        readonly=True,
+        copy=False,
+        check_company=True,
+    )
+
+    # --- Рядки ---
+    line_ids = fields.One2many(
+        'hr.vacation.reserve.line',
+        'reserve_id',
+        string='Рядки',
+        copy=False,
+    )
+    line_count = fields.Integer(
+        compute='_compute_summary',
+        store=True,
+    )
+    total_amount = fields.Monetary(
+        compute='_compute_summary',
+        store=True,
+        currency_field='currency_id',
+    )
+
+    note = fields.Text(string='Примітки')
+
+    company_id = fields.Many2one(
+        'res.company',
+        required=True,
+        default=lambda self: self.env.company,
+    )
+    currency_id = fields.Many2one(
+        related='company_id.currency_id',
+    )
+
+    @api.depends('line_ids.amount')
+    def _compute_summary(self):
+        for rec in self:
+            rec.line_count = len(rec.line_ids)
+            rec.total_amount = sum(rec.line_ids.mapped('amount'))
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get('name') or vals.get('name') == _('Нова'):
+                vals['name'] = self.env['ir.sequence'].next_by_code(
+                    'hr.vacation.reserve'
+                ) or _('Нова')
+            # Defaults from company
+            company = self.env['res.company'].browse(
+                vals.get('company_id') or self.env.company.id)
+            if not vals.get('journal_id') and company.vacation_reserve_journal_id:
+                vals['journal_id'] = company.vacation_reserve_journal_id.id
+            if not vals.get('reserve_account_id') and company.vacation_reserve_account_id:
+                vals['reserve_account_id'] = company.vacation_reserve_account_id.id
+        return super().create(vals_list)
+
+    # --- Дії ---
+
+    def action_fill_lines(self):
+        """Заповнити рядки активними працівниками компанії."""
+        self.ensure_one()
+        if self.state != 'draft':
+            raise UserError(_('Заповнити рядки можна лише з чернетки.'))
+        Employee = self.env['hr.employee']
+        Line = self.env['hr.vacation.reserve.line']
+        existing = self.line_ids.mapped('employee_id').ids
+        domain = [
+            ('company_id', '=', self.company_id.id),
+            ('active', '=', True),
+            ('id', 'not in', existing),
+        ]
+        employees = Employee.search(domain)
+        for emp in employees:
+            Line.create({
+                'reserve_id': self.id,
+                'employee_id': emp.id,
+            })
+        return True
+
+    def action_confirm(self):
+        """Підтвердити: створити проводку Дт expense / Кт 471."""
+        if self.ids:
+            self.env.cr.execute(
+                'SELECT id FROM hr_vacation_reserve WHERE id IN %s FOR UPDATE',
+                (tuple(self.ids),),
+            )
+        for rec in self:
+            if rec.state != 'draft':
+                raise UserError(_('Підтвердити можна лише з чернетки.'))
+            if not rec.line_ids:
+                raise UserError(_('Додайте хоча б один рядок.'))
+            rec._validate_accounts()
+            rec._create_account_move()
+            rec.state = 'confirmed'
+        return True
+
+    def action_cancel(self):
+        """Скасувати: спершу скасувати проводку."""
+        for rec in self:
+            if rec.state != 'confirmed':
+                raise UserError(_('Скасувати можна лише підтверджений документ.'))
+            if rec.move_id:
+                if rec.move_id.state == 'posted':
+                    rec.move_id.button_draft()
+                rec.move_id.button_cancel()
+            rec.state = 'cancelled'
+        return True
+
+    def action_draft(self):
+        for rec in self:
+            if rec.state != 'cancelled':
+                raise UserError(_('У чернетку можна повернути лише скасовану.'))
+            rec.state = 'draft'
+        return True
+
+    def action_view_move(self):
+        self.ensure_one()
+        if not self.move_id:
+            return False
+        return {
+            'name': _('Проводка резерву відпусток'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'account.move',
+            'view_mode': 'form',
+            'res_id': self.move_id.id,
+        }
+
+    def _validate_accounts(self):
+        self.ensure_one()
+        missing = []
+        if not self.journal_id:
+            missing.append(_('Журнал'))
+        if not self.reserve_account_id:
+            missing.append(_('Рахунок резерву (471)'))
+        lines_no_account = self.line_ids.filtered(lambda l: not l.expense_account_id)
+        if lines_no_account:
+            employees = lines_no_account.mapped('employee_id.display_name')
+            raise UserError(_(
+                'Не задано рахунок витрат для працівників: %s. '
+                'Налаштуйте на hr.job, hr.employee або рахунок за замовч. на компанії.'
+            ) % ', '.join(employees))
+        if missing:
+            raise UserError(_(
+                'Не заповнено: %s'
+            ) % ', '.join(missing))
+
+    def _create_account_move(self):
+        """Дт expense_account_id (за функцією) / Кт 471 для кожного рядка."""
+        self.ensure_one()
+        move_lines = []
+        ref = _('Резерв відпусток %s (%s — %s)') % (
+            self.name, self.period_start, self.period_end)
+
+        # Group by expense account to reduce line count
+        by_account = {}
+        for line in self.line_ids:
+            if not line.amount:
+                continue
+            acc = line.expense_account_id
+            by_account.setdefault(acc.id, 0.0)
+            by_account[acc.id] += line.amount
+        for acc_id, total in by_account.items():
+            move_lines.append((0, 0, {
+                'account_id': acc_id,
+                'name': _('Резерв відпусток %s') % self.name,
+                'debit': total,
+                'credit': 0.0,
+            }))
+        total = sum(by_account.values())
+        if total:
+            move_lines.append((0, 0, {
+                'account_id': self.reserve_account_id.id,
+                'name': _('Резерв відпусток %s') % self.name,
+                'debit': 0.0,
+                'credit': total,
+            }))
+        if not move_lines:
+            return
+
+        move = self.env['account.move'].create({
+            'journal_id': self.journal_id.id,
+            'date': self.period_end,
+            'ref': ref,
+            'company_id': self.company_id.id,
+            'line_ids': move_lines,
+        })
+        move.action_post()
+        self.move_id = move
+
+    def unlink(self):
+        for rec in self:
+            if rec.state == 'confirmed':
+                raise UserError(_(
+                    'Не можна видалити підтверджений документ резерву. '
+                    'Спочатку скасуйте його.'
+                ))
+        return super().unlink()
+
+    # --- Cron ---
+
+    @api.model
+    def _cron_accrue_vacation_reserve(self):
+        """Місячне нарахування резерву відпусток для кожної компанії
+        з налаштованим автоматичним нарахуванням.
+        """
+        today = fields.Date.context_today(self)
+        # Period is the previous month/quarter
+        for company in self.env['res.company'].search([
+            ('vacation_reserve_journal_id', '!=', False),
+            ('vacation_reserve_account_id', '!=', False),
+        ]):
+            freq = company.vacation_reserve_frequency or 'monthly'
+            if freq == 'monthly':
+                period_start = (today.replace(day=1) - relativedelta(months=1))
+                period_end = today.replace(day=1) - relativedelta(days=1)
+            else:  # quarterly
+                quarter_start_month = ((today.month - 1) // 3) * 3 + 1
+                period_start = (today.replace(
+                    day=1, month=quarter_start_month) - relativedelta(months=3))
+                period_end = today.replace(
+                    day=1, month=quarter_start_month) - relativedelta(days=1)
+
+            # Skip if already exists
+            existing = self.search([
+                ('company_id', '=', company.id),
+                ('period_start', '=', period_start),
+                ('period_end', '=', period_end),
+            ], limit=1)
+            if existing:
+                continue
+
+            rec = self.with_company(company).create({
+                'company_id': company.id,
+                'period_start': period_start,
+                'period_end': period_end,
+            })
+            rec.action_fill_lines()
+            try:
+                rec.action_confirm()
+            except UserError:
+                # Залишити чернеткою якщо немає рахунків — користувач
+                # розбереться вручну
+                pass
+
+
+class HrVacationReserveLine(models.Model):
+    _name = 'hr.vacation.reserve.line'
+    _description = 'Рядок резерву відпусток'
+    _order = 'reserve_id, employee_id'
+    _check_company_auto = True
+
+    reserve_id = fields.Many2one(
+        'hr.vacation.reserve',
+        string='Документ',
+        required=True,
+        ondelete='cascade',
+    )
+    company_id = fields.Many2one(
+        related='reserve_id.company_id',
+        store=True,
+    )
+    employee_id = fields.Many2one(
+        'hr.employee',
+        string='Працівник',
+        required=True,
+        domain="[('company_id', '=?', company_id), ('active', '=', True)]",
+        check_company=True,
+    )
+    days_accrued = fields.Float(
+        string='Дні нараховано',
+        compute='_compute_days_accrued',
+        store=True,
+        readonly=False,
+        precompute=True,
+        help='Дні відпустки, нараховані за період',
+    )
+    daily_average = fields.Float(
+        string='Середньоденний',
+        compute='_compute_daily_average',
+        store=True,
+        readonly=False,
+        precompute=True,
+        help='Середньоденний заробіток для розрахунку резерву',
+        digits='Payroll',
+    )
+    amount = fields.Monetary(
+        string='Сума резерву',
+        compute='_compute_amount',
+        store=True,
+        readonly=False,
+        precompute=True,
+        currency_field='currency_id',
+    )
+    expense_account_id = fields.Many2one(
+        'account.account',
+        string='Рахунок витрат',
+        compute='_compute_expense_account',
+        store=True,
+        readonly=False,
+        precompute=True,
+        check_company=True,
+        domain="[('company_ids', 'in', company_id)]",
+    )
+
+    state = fields.Selection(
+        related='reserve_id.state',
+        store=True,
+    )
+    currency_id = fields.Many2one(
+        related='reserve_id.currency_id',
+    )
+
+    @api.depends('employee_id', 'reserve_id.period_start', 'reserve_id.period_end')
+    def _compute_days_accrued(self):
+        """Дні відпустки за період = (річна норма × днів періоду) / 365."""
+        for line in self:
+            if not line.employee_id or not line.reserve_id.period_start \
+                    or not line.reserve_id.period_end:
+                line.days_accrued = 0.0
+                continue
+            annual_days = line.company_id.vacation_reserve_annual_days or 24.0
+            period_days = (line.reserve_id.period_end
+                           - line.reserve_id.period_start).days + 1
+            line.days_accrued = round(annual_days * period_days / 365.0, 2)
+
+    @api.depends('employee_id', 'reserve_id.period_end')
+    def _compute_daily_average(self):
+        """Середньоденний заробіток = sum(payslip.net за 12 місяців до кінця періоду) / (12 × 29.3)."""
+        Payslip = self.env['hr.payslip']
+        for line in self:
+            if not line.employee_id or not line.reserve_id.period_end:
+                line.daily_average = 0.0
+                continue
+            period_end = line.reserve_id.period_end
+            period_start = period_end - relativedelta(months=12)
+            payslips = Payslip.search([
+                ('employee_id', '=', line.employee_id.id),
+                ('state', 'in', ['done', 'paid']),
+                ('date_from', '>=', period_start),
+                ('date_to', '<=', period_end),
+            ])
+            if not payslips:
+                # Fallback to contract wage
+                contract = line.employee_id.version_id
+                wage = contract.wage if contract else 0.0
+                line.daily_average = round(wage / 29.3, 2)
+                continue
+            total = sum(payslips.mapped('total_net') or [0.0])
+            line.daily_average = round(total / (12 * 29.3), 2)
+
+    @api.depends('days_accrued', 'daily_average')
+    def _compute_amount(self):
+        for line in self:
+            currency = line.currency_id
+            raw = line.days_accrued * line.daily_average
+            line.amount = currency.round(raw) if currency else round(raw, 2)
+
+    @api.depends('employee_id', 'employee_id.vacation_reserve_expense_account_id',
+                 'employee_id.job_id.vacation_reserve_expense_account_id',
+                 'company_id.vacation_reserve_default_expense_account_id')
+    def _compute_expense_account(self):
+        for line in self:
+            if not line.employee_id:
+                line.expense_account_id = False
+                continue
+            line.expense_account_id = line.employee_id._get_vacation_reserve_expense_account()

--- a/l10n_ua_hr_vacation_reserve/models/res_company.py
+++ b/l10n_ua_hr_vacation_reserve/models/res_company.py
@@ -1,0 +1,48 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    vacation_reserve_journal_id = fields.Many2one(
+        'account.journal',
+        string='Журнал резерву відпусток',
+        domain="[('type', '=', 'general'), ('company_id', '=', id)]",
+        check_company=True,
+    )
+    vacation_reserve_account_id = fields.Many2one(
+        'account.account',
+        string='Рахунок резерву (471)',
+        domain="[('company_ids', 'in', id)]",
+        check_company=True,
+        help='Забезпечення виплат відпусток — за замовч. 471',
+    )
+    vacation_payable_account_id = fields.Many2one(
+        'account.account',
+        string='Рахунок виплат (661)',
+        domain="[('company_ids', 'in', id)]",
+        check_company=True,
+        help='Розрахунки з персоналом за зарплатою — за замовч. 661',
+    )
+    vacation_reserve_default_expense_account_id = fields.Many2one(
+        'account.account',
+        string='Рахунок витрат за замовч.',
+        domain="[('company_ids', 'in', id)]",
+        check_company=True,
+        help='Використовується якщо не задано на hr.job чи hr.employee '
+             '(за замовч. 91 «Адміністративні витрати»)',
+    )
+    vacation_reserve_frequency = fields.Selection(
+        selection=[
+            ('monthly', 'Щомісяця'),
+            ('quarterly', 'Щокварталу'),
+        ],
+        string='Періодичність нарахування',
+        default='monthly',
+    )
+    vacation_reserve_annual_days = fields.Float(
+        string='Дні відпустки на рік (за замовч.)',
+        default=24.0,
+        help='Базова річна норма відпустки для розрахунку резерву '
+             '(за замовч. 24 к.д. — ст. 6 ЗУ № 504)',
+    )

--- a/l10n_ua_hr_vacation_reserve/security/ir.model.access.csv
+++ b/l10n_ua_hr_vacation_reserve/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hr_vacation_reserve_user,hr.vacation.reserve.user,model_hr_vacation_reserve,hr.group_hr_user,1,1,1,0
+access_hr_vacation_reserve_manager,hr.vacation.reserve.manager,model_hr_vacation_reserve,hr.group_hr_manager,1,1,1,1
+access_hr_vacation_reserve_line_user,hr.vacation.reserve.line.user,model_hr_vacation_reserve_line,hr.group_hr_user,1,1,1,1
+access_hr_vacation_reserve_line_manager,hr.vacation.reserve.line.manager,model_hr_vacation_reserve_line,hr.group_hr_manager,1,1,1,1

--- a/l10n_ua_hr_vacation_reserve/tests/__init__.py
+++ b/l10n_ua_hr_vacation_reserve/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_vacation_reserve

--- a/l10n_ua_hr_vacation_reserve/tests/test_vacation_reserve.py
+++ b/l10n_ua_hr_vacation_reserve/tests/test_vacation_reserve.py
@@ -1,0 +1,232 @@
+"""Тести резерву відпусток — П(С)БО 26."""
+
+from datetime import date
+from odoo.tests import TransactionCase, tagged
+from odoo.exceptions import UserError
+
+
+@tagged('post_install', '-at_install')
+class TestVacationReserve(TransactionCase):
+    """Тести резерву відпусток."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+
+        cls.journal = cls.env['account.journal'].search([
+            ('type', '=', 'general'),
+            ('company_id', '=', cls.company.id),
+        ], limit=1) or cls.env['account.journal'].create({
+            'name': 'Test General',
+            'code': 'TGEN',
+            'type': 'general',
+            'company_id': cls.company.id,
+        })
+
+        Account = cls.env['account.account']
+
+        def _get_or_create(code, name, atype):
+            acc = Account.search([
+                ('code', '=', code),
+                ('company_ids', 'in', cls.company.id),
+            ], limit=1)
+            if not acc:
+                acc = Account.create({
+                    'code': code,
+                    'name': name,
+                    'account_type': atype,
+                    'company_ids': [(4, cls.company.id)],
+                })
+            return acc
+
+        cls.acc_471 = _get_or_create('4711', 'Резерв відпусток', 'liability_current')
+        cls.acc_661 = _get_or_create('6611', 'Розрахунки з персоналом', 'liability_payable')
+        cls.acc_91 = _get_or_create('9111', 'Адмін. витрати', 'expense')
+        cls.acc_23 = _get_or_create('2311', 'Виробництво', 'asset_current')
+
+        # Configure company
+        cls.company.write({
+            'vacation_reserve_journal_id': cls.journal.id,
+            'vacation_reserve_account_id': cls.acc_471.id,
+            'vacation_payable_account_id': cls.acc_661.id,
+            'vacation_reserve_default_expense_account_id': cls.acc_91.id,
+            'vacation_reserve_annual_days': 24.0,
+        })
+
+        # Test employees
+        cls.emp1 = cls.env['hr.employee'].create({
+            'name': 'Тестова Іванна',
+            'company_id': cls.company.id,
+        })
+        cls.emp2 = cls.env['hr.employee'].create({
+            'name': 'Тестовий Петро',
+            'company_id': cls.company.id,
+        })
+
+    def test_creation_sequence(self):
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+        })
+        self.assertTrue(rec.name.startswith('РВ-'))
+        self.assertEqual(rec.state, 'draft')
+        # Defaults populated from company
+        self.assertEqual(rec.journal_id, self.journal)
+        self.assertEqual(rec.reserve_account_id, self.acc_471)
+
+    def test_fill_lines(self):
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+        })
+        rec.action_fill_lines()
+        # We have created 2 test employees + may have demo ones
+        emp_ids = rec.line_ids.mapped('employee_id.id')
+        self.assertIn(self.emp1.id, emp_ids)
+        self.assertIn(self.emp2.id, emp_ids)
+
+    def test_days_accrued_computation(self):
+        """31-day period × 24 / 365 ≈ 2.04 днів."""
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+            'line_ids': [(0, 0, {'employee_id': self.emp1.id})],
+        })
+        line = rec.line_ids
+        # 24 * 31 / 365 = 2.03835... → 2.04
+        self.assertAlmostEqual(line.days_accrued, 2.04, places=2)
+
+    def test_expense_account_priority_company(self):
+        """Без override на employee/job — береться company default."""
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+            'line_ids': [(0, 0, {'employee_id': self.emp1.id})],
+        })
+        self.assertEqual(rec.line_ids.expense_account_id, self.acc_91)
+
+    def test_expense_account_priority_job(self):
+        """Job override має пріоритет над company default."""
+        job = self.env['hr.job'].create({
+            'name': 'Виробничий працівник',
+            'company_id': self.company.id,
+            'vacation_reserve_expense_account_id': self.acc_23.id,
+        })
+        self.emp1.job_id = job
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+            'line_ids': [(0, 0, {'employee_id': self.emp1.id})],
+        })
+        self.assertEqual(rec.line_ids.expense_account_id, self.acc_23)
+
+    def test_expense_account_priority_employee(self):
+        """Employee override має найвищий пріоритет."""
+        job = self.env['hr.job'].create({
+            'name': 'Виробничий',
+            'company_id': self.company.id,
+            'vacation_reserve_expense_account_id': self.acc_23.id,
+        })
+        self.emp1.job_id = job
+        self.emp1.vacation_reserve_expense_account_id = self.acc_91
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+            'line_ids': [(0, 0, {'employee_id': self.emp1.id})],
+        })
+        self.assertEqual(rec.line_ids.expense_account_id, self.acc_91)
+
+    def test_confirm_creates_balanced_move(self):
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+            'line_ids': [
+                (0, 0, {'employee_id': self.emp1.id, 'daily_average': 1000}),
+                (0, 0, {'employee_id': self.emp2.id, 'daily_average': 1500}),
+            ],
+        })
+        rec.action_confirm()
+        self.assertEqual(rec.state, 'confirmed')
+        self.assertTrue(rec.move_id)
+        self.assertEqual(rec.move_id.state, 'posted')
+        # Balance
+        debit = sum(rec.move_id.line_ids.mapped('debit'))
+        credit = sum(rec.move_id.line_ids.mapped('credit'))
+        self.assertAlmostEqual(debit, credit, places=2)
+        # Кт 471 = sum of amounts
+        kt_471 = rec.move_id.line_ids.filtered(
+            lambda l: l.account_id == self.acc_471)
+        self.assertAlmostEqual(sum(kt_471.mapped('credit')), rec.total_amount, places=2)
+        self.assertAlmostEqual(sum(kt_471.mapped('debit')), 0, places=2)
+
+    def test_confirm_groups_by_expense_account(self):
+        """Кілька працівників з тим самим рахунком — об'єднані в один Дт-рядок."""
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+            'line_ids': [
+                (0, 0, {'employee_id': self.emp1.id, 'daily_average': 1000,
+                        'expense_account_id': self.acc_91.id}),
+                (0, 0, {'employee_id': self.emp2.id, 'daily_average': 1500,
+                        'expense_account_id': self.acc_91.id}),
+            ],
+        })
+        rec.action_confirm()
+        # Усього 2 рядки в проводці: Дт 91 (агрегат) і Кт 471
+        self.assertEqual(len(rec.move_id.line_ids), 2)
+
+    def test_confirm_two_expense_accounts(self):
+        """Два різні рахунки витрат — два Дт-рядки + один Кт."""
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+            'line_ids': [
+                (0, 0, {'employee_id': self.emp1.id, 'daily_average': 1000,
+                        'expense_account_id': self.acc_91.id}),
+                (0, 0, {'employee_id': self.emp2.id, 'daily_average': 1500,
+                        'expense_account_id': self.acc_23.id}),
+            ],
+        })
+        rec.action_confirm()
+        # 3 рядки: Дт 91, Дт 23, Кт 471
+        self.assertEqual(len(rec.move_id.line_ids), 3)
+
+    def test_cancel_cancels_move(self):
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+            'line_ids': [
+                (0, 0, {'employee_id': self.emp1.id, 'daily_average': 1000}),
+            ],
+        })
+        rec.action_confirm()
+        move = rec.move_id
+        rec.action_cancel()
+        self.assertEqual(rec.state, 'cancelled')
+        self.assertEqual(move.state, 'cancel')
+
+    def test_confirm_requires_lines(self):
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+        })
+        with self.assertRaises(UserError):
+            rec.action_confirm()
+
+    def test_zero_amount_line_skipped(self):
+        """Рядок з нульовим середньоденним не створює рядка в move."""
+        rec = self.env['hr.vacation.reserve'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 1, 31),
+            'line_ids': [
+                (0, 0, {'employee_id': self.emp1.id, 'daily_average': 0}),
+                (0, 0, {'employee_id': self.emp2.id, 'daily_average': 1000}),
+            ],
+        })
+        rec.action_confirm()
+        # Тільки рядки з amount > 0 в проводці
+        self.assertTrue(rec.move_id)
+        debit = sum(rec.move_id.line_ids.mapped('debit'))
+        credit = sum(rec.move_id.line_ids.mapped('credit'))
+        self.assertAlmostEqual(debit, credit, places=2)

--- a/l10n_ua_hr_vacation_reserve/views/hr_employee_views.xml
+++ b/l10n_ua_hr_vacation_reserve/views/hr_employee_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_hr_employee_form_vacation_reserve" model="ir.ui.view">
+        <field name="name">hr.employee.form.vacation.reserve</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.view_employee_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='hr_settings']" position="inside">
+                <group string="Резерв відпусток">
+                    <field name="vacation_reserve_expense_account_id"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ua_hr_vacation_reserve/views/hr_job_views.xml
+++ b/l10n_ua_hr_vacation_reserve/views/hr_job_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_hr_job_form_vacation_reserve" model="ir.ui.view">
+        <field name="name">hr.job.form.vacation.reserve</field>
+        <field name="model">hr.job</field>
+        <field name="inherit_id" ref="hr.view_hr_job_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='department_id']" position="after">
+                <field name="vacation_reserve_expense_account_id"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ua_hr_vacation_reserve/views/hr_vacation_reserve_views.xml
+++ b/l10n_ua_hr_vacation_reserve/views/hr_vacation_reserve_views.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Form -->
+    <record id="hr_vacation_reserve_view_form" model="ir.ui.view">
+        <field name="name">hr.vacation.reserve.form</field>
+        <field name="model">hr.vacation.reserve</field>
+        <field name="arch" type="xml">
+            <form string="Резерв відпусток">
+                <header>
+                    <button name="action_fill_lines" string="Заповнити рядки"
+                            type="object" class="btn-primary"
+                            invisible="state != 'draft'"/>
+                    <button name="action_confirm" string="Підтвердити"
+                            type="object" class="btn-primary"
+                            invisible="state != 'draft'"
+                            confirm="Підтвердити документ резерву? Буде створена бухгалтерська проводка."/>
+                    <button name="action_cancel" string="Скасувати"
+                            type="object" class="btn-danger"
+                            invisible="state != 'confirmed'"/>
+                    <button name="action_draft" string="Повернути в чернетку"
+                            type="object"
+                            invisible="state != 'cancelled'"/>
+                    <field name="state" widget="statusbar"
+                           statusbar_visible="draft,confirmed"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_view_move" type="object"
+                                class="oe_stat_button" icon="fa-pencil-square-o"
+                                invisible="not move_id">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Проводка</span>
+                            </div>
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" readonly="1"/></h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="period_start" readonly="state != 'draft'"/>
+                            <field name="period_end" readonly="state != 'draft'"/>
+                            <field name="company_id" groups="base.group_multi_company"
+                                   readonly="state != 'draft'"/>
+                            <field name="currency_id" invisible="1"/>
+                        </group>
+                        <group string="Бухгалтерія">
+                            <field name="journal_id" readonly="state != 'draft'"/>
+                            <field name="reserve_account_id" readonly="state != 'draft'"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Рядки" name="lines">
+                            <field name="line_ids" readonly="state != 'draft'">
+                                <list editable="bottom" string="Рядки">
+                                    <field name="employee_id"/>
+                                    <field name="expense_account_id"/>
+                                    <field name="days_accrued"/>
+                                    <field name="daily_average"/>
+                                    <field name="amount" sum="Усього"/>
+                                    <field name="currency_id" column_invisible="1"/>
+                                </list>
+                            </field>
+                            <group class="oe_subtotal_footer">
+                                <field name="line_count"/>
+                                <field name="total_amount"
+                                       class="oe_subtotal_footer_separator"/>
+                            </group>
+                        </page>
+                        <page string="Примітки" name="note">
+                            <field name="note"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- List -->
+    <record id="hr_vacation_reserve_view_list" model="ir.ui.view">
+        <field name="name">hr.vacation.reserve.list</field>
+        <field name="model">hr.vacation.reserve</field>
+        <field name="arch" type="xml">
+            <list string="Резерв відпусток"
+                  decoration-info="state == 'draft'"
+                  decoration-success="state == 'confirmed'"
+                  decoration-muted="state == 'cancelled'">
+                <field name="name"/>
+                <field name="period_start"/>
+                <field name="period_end"/>
+                <field name="line_count"/>
+                <field name="total_amount" sum="Усього"/>
+                <field name="state" widget="badge"
+                       decoration-info="state == 'draft'"
+                       decoration-success="state == 'confirmed'"
+                       decoration-muted="state == 'cancelled'"/>
+                <field name="currency_id" column_invisible="1"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Search -->
+    <record id="hr_vacation_reserve_view_search" model="ir.ui.view">
+        <field name="name">hr.vacation.reserve.search</field>
+        <field name="model">hr.vacation.reserve</field>
+        <field name="arch" type="xml">
+            <search string="Резерв відпусток">
+                <field name="name"/>
+                <field name="line_ids" string="Працівник"
+                       filter_domain="[('line_ids.employee_id.name', 'ilike', self)]"/>
+
+                <filter string="Чернетки" name="filter_draft"
+                        domain="[('state', '=', 'draft')]"/>
+                <filter string="Підтверджені" name="filter_confirmed"
+                        domain="[('state', '=', 'confirmed')]"/>
+
+                <group>
+                    <filter string="Стан" name="groupby_state" domain="[]"
+                            context="{'group_by': 'state'}"/>
+                    <filter string="Період" name="groupby_period" domain="[]"
+                            context="{'group_by': 'period_end:month'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="hr_vacation_reserve_action" model="ir.actions.act_window">
+        <field name="name">Резерв відпусток</field>
+        <field name="res_model">hr.vacation.reserve</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="hr_vacation_reserve_view_search"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">Створіть перший документ резерву</p>
+            <p>
+                Щомісячне нарахування резерву відпусток згідно
+                П(С)БО 26 «Виплати працівникам». Дт витрат / Кт 471.
+            </p>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ua_hr_vacation_reserve/views/menu_views.xml
+++ b/l10n_ua_hr_vacation_reserve/views/menu_views.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <menuitem id="menu_hr_vacation_reserve"
+              name="Vacation Reserve"
+              parent="hr_holidays.menu_hr_holidays_root"
+              action="hr_vacation_reserve_action"
+              sequence="30"
+              groups="hr.group_hr_user"/>
+
+</odoo>

--- a/l10n_ua_hr_vacation_reserve/views/res_company_views.xml
+++ b/l10n_ua_hr_vacation_reserve/views/res_company_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_res_company_form_vacation_reserve" model="ir.ui.view">
+        <field name="name">res.company.form.vacation.reserve</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Резерв відпусток" name="vacation_reserve">
+                    <group>
+                        <group string="Бухгалтерія">
+                            <field name="vacation_reserve_journal_id"/>
+                            <field name="vacation_reserve_account_id"/>
+                            <field name="vacation_payable_account_id"/>
+                            <field name="vacation_reserve_default_expense_account_id"/>
+                        </group>
+                        <group string="Параметри нарахування">
+                            <field name="vacation_reserve_frequency"/>
+                            <field name="vacation_reserve_annual_days"/>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Опис

Новий модуль `l10n_ua_hr_vacation_reserve` — автоматичне нарахування резерву відпусток згідно П(С)БО 26 «Виплати працівникам» та ст. 23.4 ПКУ.

Closes #84

## Моделі

- **`hr.vacation.reserve`** — документ нарахування (master) зі станами `draft → confirmed → cancelled`
- **`hr.vacation.reserve.line`** — рядок по працівнику з computed-полями:
  - `days_accrued` = (період в днях × річна норма / 365)
  - `daily_average` = 12-міс. середній чистий заробіток (fallback на contract.wage / 29.3)
  - `amount` = days_accrued × daily_average
  - `expense_account_id` — за пріоритетом employee → job → company default
- **`res.company`** — налаштування: журнал, рахунки 471/661/витрат, періодичність, річна норма (за замовч. 24 к.д.)
- **`hr.job`** — рахунок витрат за функцією (23/91/92/93)
- **`hr.employee`** — override per employee + helper для пріоритету
- **`hr.payslip`** — hook на `action_payslip_done` створює обернену проводку

## Workflow

1. Створити документ (з налаштуваннями за замовч. з компанії)
2. «Заповнити рядки» — додає всіх активних працівників компанії
3. Поля рахуються автоматично, користувач може overriде
4. «Підтвердити» — групує рядки по `expense_account_id`, створює `account.move`:
   - **Дт expense (23/91/92/93)** — окремий рядок на кожен рахунок
   - **Кт 471** — агрегат
5. При нарахуванні відпускних у payslip — hook автоматично створює:
   - **Дт 471 / Кт 661** на суму payslip.accrual_ids з category='vacation'

## Cron

`_cron_accrue_vacation_reserve` — щомісячно для кожної компанії з налаштованим резервом, створює документ за попередній період і пробує підтвердити. Вимкнено за замовч. — адміністратор вмикає після налаштування.

## Тестування

12 тестів, 0 failed:
- послідовність ІНВ-...
- заповнення рядків
- обчислення `days_accrued` (31 день × 24/365 ≈ 2.04)
- пріоритет експенс-рахунку (company / job / employee)
- confirm створює балансовану проводку
- групування по expense_account_id
- два різні рахунки → 3 рядки в проводці
- cancel скасовує проводку
- блокування confirm без рядків
- skip рядка з нульовою сумою

## Test plan

- [x] `odoo -i l10n_ua_hr_vacation_reserve --test-enable` — 0 failed
- [ ] Налаштувати компанію (471, 661, 91, журнал)
- [ ] Створити документ за період, заповнити, підтвердити — перевірити проводку Дт 91 / Кт 471
- [ ] Створити payslip з відпускними — перевірити обернену проводку Дт 471 / Кт 661
- [ ] Скасувати payslip — перевірити що реверс-проводка скасовується

🤖 Generated with [Claude Code](https://claude.com/claude-code)