### PR TITLE
feat(tax_4df): 4ДФ — об'єднана звітність ПДФО/ВЗ/ЄСВ (закриває #77)

### DIFF
--- a/l10n_ua_tax_4df/__init__.py
+++ b/l10n_ua_tax_4df/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ua_tax_4df/__manifest__.py
+++ b/l10n_ua_tax_4df/__manifest__.py
@@ -1,0 +1,42 @@
+{
+    'name': 'Ukraine - 4DF Unified Tax Report',
+    'version': '19.0.1.0.0',
+    'category': 'Accounting/Localization',
+    'summary': '4ДФ — об\'єднана квартальна звітність ПДФО/ВЗ/ЄСВ '
+               '(заміна 1ДФ + Д5 з 01.01.2021)',
+    'description': """
+Ukraine 4DF Unified Tax Report (J0501T01 / F0501T01)
+=====================================================
+
+Quarterly combined report on PDFO / Military Tax / ESV. Replaced
+1DF and D5 from 2021-01-01.
+
+* Header model + Appendix 4ДФ (per-person PDFO/Military)
+* Appendix 1 (ESV summary per person)
+* Aggregation from hr.payslip
+* XML export (basic structure; full XSD validation — separate task)
+
+Regulatory base: Наказ Мінфіну № 4 від 13.01.2015 зі змінами,
+форма J0501T01 (юрособа) / F0501T01 (ФОП).
+
+This is an ACCOUNTING/TAX report, not an HR operational tool. It
+aggregates payroll data calculated by l10n_ua_hr_salary and produces
+a filing for submission through M.E.Doc / FREDO / Tax Cabinet.
+    """,
+    'author': 'Svyatoslav Nadozirny',
+    'website': 'https://many2one.online',
+    'license': 'LGPL-3',
+    'depends': [
+        'account',
+        'l10n_ua_account_base',
+        'l10n_ua_hr_salary',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/l10n_ua_tax_4df_views.xml',
+        'views/menu_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/l10n_ua_tax_4df/models/__init__.py
+++ b/l10n_ua_tax_4df/models/__init__.py
@@ -1,0 +1,1 @@
+from . import l10n_ua_tax_4df

--- a/l10n_ua_tax_4df/models/l10n_ua_tax_4df.py
+++ b/l10n_ua_tax_4df/models/l10n_ua_tax_4df.py
@@ -1,0 +1,456 @@
+"""4ДФ — об'єднана квартальна звітність з ПДФО/ВЗ/ЄСВ.
+
+Замінила 1ДФ і Д5 з 01.01.2021. Подається щоквартально через
+М.Е.Doc / FREDO / Електронний кабінет ДПС.
+
+Форма J0501T01 (юридична особа) / F0501T01 (ФОП).
+Нормативка: Наказ Мінфіну № 4 від 13.01.2015 зі змінами.
+
+MVP scope:
+- Header model + Appendix 4DF (per person PDFO/ВЗ) + Appendix 1 (ЄСВ summary)
+- Appendix 5 (insured persons) і Appendix 6 (hazardous workers) — TODO
+- XML export — basic stub; повна валідація по XSD ДПС — окрема задача
+"""
+
+from datetime import date
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class L10nUaTax4DF(models.Model):
+    _name = 'l10n_ua.tax.4df'
+    _description = '4ДФ — об\'єднана звітність ПДФО/ВЗ/ЄСВ'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _order = 'year desc, quarter desc'
+
+    name = fields.Char(
+        compute='_compute_name',
+        store=True,
+    )
+    year = fields.Integer(
+        string='Рік',
+        required=True,
+        default=lambda self: fields.Date.today().year,
+        tracking=True,
+    )
+    quarter = fields.Selection(
+        selection=[
+            ('1', 'I квартал'),
+            ('2', 'II квартал'),
+            ('3', 'III квартал'),
+            ('4', 'IV квартал'),
+        ],
+        string='Квартал',
+        required=True,
+        tracking=True,
+    )
+    form_code = fields.Selection(
+        selection=[
+            ('J0501T01', 'J0501T01 — юридична особа'),
+            ('F0501T01', 'F0501T01 — ФОП'),
+        ],
+        string='Код форми',
+        default='J0501T01',
+        tracking=True,
+    )
+
+    company_id = fields.Many2one(
+        'res.company',
+        string='Компанія',
+        default=lambda self: self.env.company,
+        required=True,
+    )
+    currency_id = fields.Many2one(related='company_id.currency_id')
+
+    # --- Підстановки додатків ---
+    line_4df_ids = fields.One2many(
+        'l10n_ua.tax.4df.line.4df',
+        'report_id',
+        string='Додаток 4ДФ (ПДФО/ВЗ по фізособах)',
+    )
+    line_t1_ids = fields.One2many(
+        'l10n_ua.tax.4df.line.t1',
+        'report_id',
+        string='Додаток 1 (ЄСВ по фізособах)',
+    )
+
+    # --- Підсумки ---
+    total_employees = fields.Integer(
+        compute='_compute_totals',
+        store=True,
+    )
+    total_accrued = fields.Monetary(
+        compute='_compute_totals',
+        store=True,
+        currency_field='currency_id',
+    )
+    total_pdfo = fields.Monetary(
+        compute='_compute_totals',
+        store=True,
+        currency_field='currency_id',
+    )
+    total_military = fields.Monetary(
+        compute='_compute_totals',
+        store=True,
+        currency_field='currency_id',
+    )
+    total_esv_base = fields.Monetary(
+        compute='_compute_totals',
+        store=True,
+        currency_field='currency_id',
+    )
+    total_esv = fields.Monetary(
+        compute='_compute_totals',
+        store=True,
+        currency_field='currency_id',
+    )
+
+    # --- Стан ---
+    state = fields.Selection(
+        selection=[
+            ('draft', 'Чернетка'),
+            ('generated', 'Згенеровано'),
+            ('submitted', 'Подано'),
+        ],
+        default='draft',
+        tracking=True,
+        copy=False,
+    )
+    submission_date = fields.Date(string='Дата подання')
+    xml_file = fields.Binary(string='XML-файл', attachment=True, copy=False)
+    xml_filename = fields.Char(copy=False)
+    notes = fields.Text(string='Примітки')
+
+    _unique_year_quarter_company = models.Constraint(
+        'unique(year, quarter, company_id)',
+        '4ДФ за цей період вже існує для цієї компанії!',
+    )
+
+    @api.depends('year', 'quarter')
+    def _compute_name(self):
+        for rec in self:
+            if rec.year and rec.quarter:
+                rec.name = '4ДФ %s Q%s' % (rec.year, rec.quarter)
+            else:
+                rec.name = _('Нова')
+
+    @api.depends('line_4df_ids', 'line_4df_ids.accrued_amount',
+                 'line_4df_ids.pdfo_amount', 'line_4df_ids.military_amount',
+                 'line_t1_ids', 'line_t1_ids.esv_base', 'line_t1_ids.esv_amount')
+    def _compute_totals(self):
+        for rec in self:
+            employee_ids = set(rec.line_4df_ids.mapped('employee_id.id'))
+            employee_ids.update(rec.line_t1_ids.mapped('employee_id.id'))
+            rec.total_employees = len(employee_ids)
+            rec.total_accrued = sum(rec.line_4df_ids.mapped('accrued_amount'))
+            rec.total_pdfo = sum(rec.line_4df_ids.mapped('pdfo_amount'))
+            rec.total_military = sum(rec.line_4df_ids.mapped('military_amount'))
+            rec.total_esv_base = sum(rec.line_t1_ids.mapped('esv_base'))
+            rec.total_esv = sum(rec.line_t1_ids.mapped('esv_amount'))
+
+    # --- Дії ---
+
+    def _get_quarter_dates(self):
+        """Повертає (date_from, date_to) для періоду звіту."""
+        self.ensure_one()
+        quarter_months = {
+            '1': (1, 3),
+            '2': (4, 6),
+            '3': (7, 9),
+            '4': (10, 12),
+        }
+        first_month, last_month = quarter_months[self.quarter]
+        date_from = date(self.year, first_month, 1)
+        # Last day of last_month
+        if last_month == 12:
+            date_to = date(self.year, 12, 31)
+        else:
+            next_month_first = date(self.year, last_month + 1, 1)
+            from dateutil.relativedelta import relativedelta
+            date_to = next_month_first - relativedelta(days=1)
+        return date_from, date_to
+
+    def action_generate(self):
+        """Згенерувати додатки з payslips за квартал."""
+        for rec in self:
+            if rec.state == 'submitted':
+                raise UserError(_('Не можна перегенерувати поданий звіт.'))
+            rec.line_4df_ids.unlink()
+            rec.line_t1_ids.unlink()
+            rec._generate_appendix_4df()
+            rec._generate_appendix_t1()
+            rec.state = 'generated'
+        return True
+
+    def _generate_appendix_4df(self):
+        """Додаток 4ДФ — ПДФО/ВЗ по фізособах (наступник 1ДФ)."""
+        self.ensure_one()
+        Line = self.env['l10n_ua.tax.4df.line.4df']
+        date_from, date_to = self._get_quarter_dates()
+        payslips = self.env['hr.payslip'].search([
+            ('company_id', '=', self.company_id.id),
+            ('date_from', '>=', date_from),
+            ('date_to', '<=', date_to),
+            ('state', 'in', ['done', 'paid']),
+        ])
+        by_emp = {}
+        for slip in payslips:
+            emp_id = slip.employee_id.id
+            d = by_emp.setdefault(emp_id, {
+                'accrued': 0.0, 'paid': 0.0,
+                'pdfo': 0.0, 'military': 0.0,
+            })
+            d['accrued'] += slip.gross_salary
+            d['paid'] += slip.net_salary
+            d['pdfo'] += slip.pdfo_amount
+            d['military'] += slip.military_tax_amount
+        for emp_id, d in by_emp.items():
+            employee = self.env['hr.employee'].browse(emp_id)
+            date_hire, date_termination = self._employee_period_dates(
+                employee, date_from, date_to)
+            Line.create({
+                'report_id': self.id,
+                'employee_id': emp_id,
+                'rnokpp': employee.rnokpp or '',
+                'income_type': '101',
+                'income_sign': '0',
+                'accrued_amount': d['accrued'],
+                'paid_amount': d['paid'],
+                'pdfo_amount': d['pdfo'],
+                'military_amount': d['military'],
+                'date_hire': date_hire,
+                'date_termination': date_termination,
+            })
+
+    def _generate_appendix_t1(self):
+        """Додаток 1 — Зведена відомість ЄСВ по фізособах."""
+        self.ensure_one()
+        Line = self.env['l10n_ua.tax.4df.line.t1']
+        date_from, date_to = self._get_quarter_dates()
+        payslips = self.env['hr.payslip'].search([
+            ('company_id', '=', self.company_id.id),
+            ('date_from', '>=', date_from),
+            ('date_to', '<=', date_to),
+            ('state', 'in', ['done', 'paid']),
+        ])
+        by_emp = {}
+        for slip in payslips:
+            emp_id = slip.employee_id.id
+            d = by_emp.setdefault(emp_id, {
+                'accrued': 0.0, 'esv_base': 0.0, 'esv': 0.0,
+                'months': set(),
+            })
+            d['accrued'] += slip.gross_salary
+            d['esv_base'] += slip.esv_base
+            d['esv'] += slip.esv_amount
+            d['months'].add((slip.date_from.year, slip.date_from.month))
+        for emp_id, d in by_emp.items():
+            employee = self.env['hr.employee'].browse(emp_id)
+            Line.create({
+                'report_id': self.id,
+                'employee_id': emp_id,
+                'rnokpp': employee.rnokpp or '',
+                'accrued_amount': d['accrued'],
+                'esv_base': d['esv_base'],
+                'esv_amount': d['esv'],
+                'months_count': len(d['months']),
+            })
+
+    @staticmethod
+    def _employee_period_dates(employee, date_from, date_to):
+        """Повертає (date_hire, date_termination) у межах періоду звіту."""
+        date_hire = False
+        date_termination = False
+        version = employee.current_version_id
+        if version:
+            start = version.contract_date_start
+            end = getattr(version, 'contract_date_end', None)
+            if start and date_from <= start <= date_to:
+                date_hire = start
+            if end and date_from <= end <= date_to:
+                date_termination = end
+        return date_hire, date_termination
+
+    # --- Стан ---
+
+    def action_submit(self):
+        for rec in self:
+            if rec.state != 'generated':
+                raise UserError(_('Подати можна лише згенерований звіт.'))
+            rec.write({
+                'state': 'submitted',
+                'submission_date': fields.Date.today(),
+            })
+        return True
+
+    def action_draft(self):
+        for rec in self:
+            rec.write({
+                'state': 'draft',
+                'submission_date': False,
+            })
+        return True
+
+    def action_generate_xml(self):
+        """Сформувати XML-файл звіту (заглушка-структура).
+
+        Повна валідація по XSD ДПС/ПФУ — окрема задача (FREDO/М.Е.Doc).
+        """
+        import base64
+        from xml.sax.saxutils import escape
+        for rec in self:
+            if rec.state == 'draft':
+                raise UserError(_('Спочатку згенеруйте звіт з payslips.'))
+            rec.xml_file = base64.b64encode(rec._build_xml_bytes())
+            rec.xml_filename = '%s_%s_Q%s.xml' % (
+                rec.form_code, rec.year, rec.quarter)
+        return True
+
+    def _build_xml_bytes(self):
+        """Побудувати XML-байти. Структура — спрощена."""
+        self.ensure_one()
+        from xml.sax.saxutils import escape
+        lines = ['<?xml version="1.0" encoding="UTF-8"?>']
+        lines.append('<DECLAR xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">')
+        lines.append('<DECLARHEAD>')
+        lines.append('<TIN>%s</TIN>' % escape(
+            self.company_id.partner_id.company_registry or ''))
+        lines.append('<C_DOC>%s</C_DOC>' % escape(self.form_code or ''))
+        lines.append('<PERIOD_MONTH>%s</PERIOD_MONTH>' % (int(self.quarter) * 3))
+        lines.append('<PERIOD_YEAR>%s</PERIOD_YEAR>' % self.year)
+        lines.append('<C_STI_ORIG>%s</C_STI_ORIG>' % escape(
+            self.company_id.name or ''))
+        lines.append('</DECLARHEAD>')
+        lines.append('<DECLARBODY>')
+        # Appendix 4DF — per person
+        lines.append('<T1RXXXXG1S>')
+        for line in self.line_4df_ids:
+            lines.append('<ROW>')
+            lines.append('<RNOKPP>%s</RNOKPP>' % escape(line.rnokpp or ''))
+            lines.append('<ACCRUED>%.2f</ACCRUED>' % line.accrued_amount)
+            lines.append('<PAID>%.2f</PAID>' % line.paid_amount)
+            lines.append('<PDFO>%.2f</PDFO>' % line.pdfo_amount)
+            lines.append('<MILITARY>%.2f</MILITARY>' % line.military_amount)
+            lines.append('<INCOME_TYPE>%s</INCOME_TYPE>' % escape(
+                line.income_type or ''))
+            if line.date_hire:
+                lines.append('<DATE_HIRE>%s</DATE_HIRE>' % line.date_hire)
+            if line.date_termination:
+                lines.append('<DATE_TERMINATION>%s</DATE_TERMINATION>' %
+                             line.date_termination)
+            lines.append('</ROW>')
+        lines.append('</T1RXXXXG1S>')
+        # Appendix 1 — ESV
+        lines.append('<T1RXXXXG2S>')
+        for line in self.line_t1_ids:
+            lines.append('<ROW>')
+            lines.append('<RNOKPP>%s</RNOKPP>' % escape(line.rnokpp or ''))
+            lines.append('<ACCRUED>%.2f</ACCRUED>' % line.accrued_amount)
+            lines.append('<ESV_BASE>%.2f</ESV_BASE>' % line.esv_base)
+            lines.append('<ESV>%.2f</ESV>' % line.esv_amount)
+            lines.append('<MONTHS>%s</MONTHS>' % line.months_count)
+            lines.append('</ROW>')
+        lines.append('</T1RXXXXG2S>')
+        lines.append('</DECLARBODY>')
+        lines.append('</DECLAR>')
+        return '\n'.join(lines).encode('utf-8')
+
+
+class L10nUaTax4DFLine4DF(models.Model):
+    _name = 'l10n_ua.tax.4df.line.4df'
+    _description = 'Додаток 4ДФ — ПДФО/ВЗ по фізособах'
+    _order = 'employee_id'
+
+    report_id = fields.Many2one(
+        'l10n_ua.tax.4df',
+        string='Звіт',
+        required=True,
+        ondelete='cascade',
+    )
+    company_id = fields.Many2one(related='report_id.company_id', store=True)
+    currency_id = fields.Many2one(related='report_id.currency_id')
+
+    employee_id = fields.Many2one(
+        'hr.employee',
+        string='Працівник',
+        required=True,
+    )
+    rnokpp = fields.Char(
+        string='РНОКПП',
+        required=True,
+        size=10,
+    )
+    income_type = fields.Char(
+        string='Код типу доходу',
+        default='101',
+        help='Код ознаки доходу (за класифікатором ДПС, типово 101 — зарплата)',
+    )
+    income_sign = fields.Selection(
+        selection=[
+            ('0', 'Нараховано і виплачено'),
+            ('1', 'Лише нараховано'),
+        ],
+        string='Ознака доходу',
+        default='0',
+    )
+    accrued_amount = fields.Monetary(
+        string='Нараховано',
+        currency_field='currency_id',
+    )
+    paid_amount = fields.Monetary(
+        string='Виплачено',
+        currency_field='currency_id',
+    )
+    pdfo_amount = fields.Monetary(
+        string='ПДФО',
+        currency_field='currency_id',
+    )
+    military_amount = fields.Monetary(
+        string='Військовий збір',
+        currency_field='currency_id',
+    )
+    date_hire = fields.Date(string='Дата прийому (квартал)')
+    date_termination = fields.Date(string='Дата звільнення (квартал)')
+
+
+class L10nUaTax4DFLineT1(models.Model):
+    _name = 'l10n_ua.tax.4df.line.t1'
+    _description = 'Додаток 1 — ЄСВ по фізособах'
+    _order = 'employee_id'
+
+    report_id = fields.Many2one(
+        'l10n_ua.tax.4df',
+        string='Звіт',
+        required=True,
+        ondelete='cascade',
+    )
+    company_id = fields.Many2one(related='report_id.company_id', store=True)
+    currency_id = fields.Many2one(related='report_id.currency_id')
+
+    employee_id = fields.Many2one(
+        'hr.employee',
+        string='Працівник',
+        required=True,
+    )
+    rnokpp = fields.Char(
+        string='РНОКПП',
+        required=True,
+        size=10,
+    )
+    accrued_amount = fields.Monetary(
+        string='Нараховано (база до обмежень)',
+        currency_field='currency_id',
+    )
+    esv_base = fields.Monetary(
+        string='База ЄСВ',
+        currency_field='currency_id',
+        help='Сума з урахуванням мін/макс обмежень ЄСВ',
+    )
+    esv_amount = fields.Monetary(
+        string='Нараховано ЄСВ',
+        currency_field='currency_id',
+    )
+    months_count = fields.Integer(
+        string='Місяців відпрацьовано',
+    )

--- a/l10n_ua_tax_4df/security/ir.model.access.csv
+++ b/l10n_ua_tax_4df/security/ir.model.access.csv
@@ -1,0 +1,7 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_l10n_ua_tax_4df_user,l10n_ua.tax.4df.user,model_l10n_ua_tax_4df,account.group_account_user,1,1,1,0
+access_l10n_ua_tax_4df_manager,l10n_ua.tax.4df.manager,model_l10n_ua_tax_4df,account.group_account_manager,1,1,1,1
+access_l10n_ua_tax_4df_line_4df_user,l10n_ua.tax.4df.line.4df.user,model_l10n_ua_tax_4df_line_4df,account.group_account_user,1,1,1,1
+access_l10n_ua_tax_4df_line_4df_manager,l10n_ua.tax.4df.line.4df.manager,model_l10n_ua_tax_4df_line_4df,account.group_account_manager,1,1,1,1
+access_l10n_ua_tax_4df_line_t1_user,l10n_ua.tax.4df.line.t1.user,model_l10n_ua_tax_4df_line_t1,account.group_account_user,1,1,1,1
+access_l10n_ua_tax_4df_line_t1_manager,l10n_ua.tax.4df.line.t1.manager,model_l10n_ua_tax_4df_line_t1,account.group_account_manager,1,1,1,1

--- a/l10n_ua_tax_4df/tests/__init__.py
+++ b/l10n_ua_tax_4df/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_4df

--- a/l10n_ua_tax_4df/tests/test_4df.py
+++ b/l10n_ua_tax_4df/tests/test_4df.py
@@ -1,0 +1,247 @@
+"""Тести 4ДФ — об'єднана звітність ПДФО/ВЗ/ЄСВ."""
+
+import base64
+from datetime import date
+
+from odoo.tests import TransactionCase, tagged
+from odoo.exceptions import UserError
+
+
+@tagged('post_install', '-at_install')
+class TestReport4DF(TransactionCase):
+    """Тести квартального звіту 4ДФ."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        # Disable RNOKPP checksum validation for tests
+        cls.env['ir.config_parameter'].sudo().set_param(
+            'hr_ua.validate_rnokpp', 'False')
+        cls.emp1 = cls.env['hr.employee'].create({
+            'name': 'Тестова Іванна',
+            'company_id': cls.company.id,
+            'rnokpp': '1234567890',
+        })
+        cls.emp2 = cls.env['hr.employee'].create({
+            'name': 'Тестовий Петро',
+            'company_id': cls.company.id,
+            'rnokpp': '0987654321',
+        })
+        cls.accrual_type = cls.env['hr.accrual.type'].search(
+            [('category', '=', 'wage')], limit=1
+        ) or cls.env['hr.accrual.type'].create({
+            'name': 'Тестова ЗП',
+            'code': 'TEST_WAGE',
+            'category': 'wage',
+            'is_taxable_pdfo': True,
+            'is_military_tax': True,
+            'is_esv_base': True,
+        })
+
+    def _create_payslip(self, employee, date_from, date_to, gross, pdfo, military,
+                       esv_base, esv, net=None):
+        slip = self.env['hr.payslip'].create({
+            'employee_id': employee.id,
+            'company_id': self.company.id,
+            'date_from': date_from,
+            'date_to': date_to,
+            'accrual_ids': [(0, 0, {
+                'accrual_type_id': self.accrual_type.id,
+                'amount': gross,
+            })],
+        })
+        # Trigger compute, then override stored values directly to control
+        # test assertions deterministically (avoid drift from tax-rate logic).
+        slip.flush_recordset()
+        self.env.cr.execute(
+            'UPDATE hr_payslip SET gross_salary=%s, net_salary=%s, '
+            'pdfo_amount=%s, military_tax_amount=%s, esv_base=%s, '
+            'esv_amount=%s, state=%s WHERE id=%s',
+            (gross, net if net is not None else (gross - pdfo - military),
+             pdfo, military, esv_base, esv, 'done', slip.id),
+        )
+        slip.invalidate_recordset()
+        return slip
+
+    def test_creation_and_name(self):
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025,
+            'quarter': '1',
+        })
+        self.assertEqual(rec.name, '4ДФ 2025 Q1')
+        self.assertEqual(rec.state, 'draft')
+
+    def test_unique_period_company(self):
+        self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        with self.assertRaises(Exception):
+            self.env['l10n_ua.tax.4df'].create({
+                'year': 2025, 'quarter': '1',
+            })
+
+    def test_quarter_dates(self):
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        date_from, date_to = rec._get_quarter_dates()
+        self.assertEqual(date_from, date(2025, 1, 1))
+        self.assertEqual(date_to, date(2025, 3, 31))
+
+        rec.quarter = '4'
+        date_from, date_to = rec._get_quarter_dates()
+        self.assertEqual(date_from, date(2025, 10, 1))
+        self.assertEqual(date_to, date(2025, 12, 31))
+
+    def test_generate_aggregates_per_employee(self):
+        # Два payslips для emp1 у Q1
+        self._create_payslip(self.emp1, date(2025, 1, 1), date(2025, 1, 31),
+                            gross=10000, pdfo=1800, military=500,
+                            esv_base=10000, esv=2200)
+        self._create_payslip(self.emp1, date(2025, 2, 1), date(2025, 2, 28),
+                            gross=12000, pdfo=2160, military=600,
+                            esv_base=12000, esv=2640)
+        # Один для emp2
+        self._create_payslip(self.emp2, date(2025, 3, 1), date(2025, 3, 31),
+                            gross=15000, pdfo=2700, military=750,
+                            esv_base=15000, esv=3300)
+
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        rec.action_generate()
+        self.assertEqual(rec.state, 'generated')
+        # Appendix 4DF — 2 рядки (по працівнику)
+        self.assertEqual(len(rec.line_4df_ids), 2)
+        emp1_line = rec.line_4df_ids.filtered(lambda l: l.employee_id == self.emp1)
+        self.assertAlmostEqual(emp1_line.accrued_amount, 22000, places=2)
+        self.assertAlmostEqual(emp1_line.pdfo_amount, 3960, places=2)
+        self.assertAlmostEqual(emp1_line.military_amount, 1100, places=2)
+        emp2_line = rec.line_4df_ids.filtered(lambda l: l.employee_id == self.emp2)
+        self.assertAlmostEqual(emp2_line.accrued_amount, 15000, places=2)
+
+        # Appendix 1 — теж 2 рядки
+        self.assertEqual(len(rec.line_t1_ids), 2)
+        emp1_t1 = rec.line_t1_ids.filtered(lambda l: l.employee_id == self.emp1)
+        self.assertAlmostEqual(emp1_t1.esv_base, 22000, places=2)
+        self.assertAlmostEqual(emp1_t1.esv_amount, 4840, places=2)
+        # emp1 — 2 місяці (Jan + Feb)
+        self.assertEqual(emp1_t1.months_count, 2)
+
+    def test_totals_computed(self):
+        self._create_payslip(self.emp1, date(2025, 1, 1), date(2025, 1, 31),
+                            gross=10000, pdfo=1800, military=500,
+                            esv_base=10000, esv=2200)
+        self._create_payslip(self.emp2, date(2025, 1, 1), date(2025, 1, 31),
+                            gross=15000, pdfo=2700, military=750,
+                            esv_base=15000, esv=3300)
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        rec.action_generate()
+        self.assertEqual(rec.total_employees, 2)
+        self.assertAlmostEqual(rec.total_accrued, 25000, places=2)
+        self.assertAlmostEqual(rec.total_pdfo, 4500, places=2)
+        self.assertAlmostEqual(rec.total_military, 1250, places=2)
+        self.assertAlmostEqual(rec.total_esv, 5500, places=2)
+
+    def test_xml_export(self):
+        self._create_payslip(self.emp1, date(2025, 1, 1), date(2025, 1, 31),
+                            gross=10000, pdfo=1800, military=500,
+                            esv_base=10000, esv=2200)
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        rec.action_generate()
+        rec.action_generate_xml()
+        self.assertTrue(rec.xml_file)
+        self.assertTrue(rec.xml_filename.startswith('J0501T01'))
+        xml = base64.b64decode(rec.xml_file).decode('utf-8')
+        self.assertIn('<DECLAR', xml)
+        self.assertIn('<RNOKPP>1234567890</RNOKPP>', xml)
+        self.assertIn('<PDFO>1800.00</PDFO>', xml)
+
+    def test_submit_workflow(self):
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        rec.action_generate()
+        rec.action_submit()
+        self.assertEqual(rec.state, 'submitted')
+        self.assertTrue(rec.submission_date)
+
+    def test_cannot_submit_from_draft(self):
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        with self.assertRaises(UserError):
+            rec.action_submit()
+
+    def test_draft_resets_submission_date(self):
+        self._create_payslip(self.emp1, date(2025, 1, 1), date(2025, 1, 31),
+                            gross=10000, pdfo=1800, military=500,
+                            esv_base=10000, esv=2200)
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        rec.action_generate()
+        rec.action_submit()
+        rec.action_draft()
+        self.assertEqual(rec.state, 'draft')
+        self.assertFalse(rec.submission_date)
+
+    def test_regenerate_blocked_after_submission(self):
+        self._create_payslip(self.emp1, date(2025, 1, 1), date(2025, 1, 31),
+                            gross=10000, pdfo=1800, military=500,
+                            esv_base=10000, esv=2200)
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        rec.action_generate()
+        rec.action_submit()
+        with self.assertRaises(UserError):
+            rec.action_generate()
+
+    def test_form_code_default(self):
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        self.assertEqual(rec.form_code, 'J0501T01')
+
+    def test_other_quarter_payslips_excluded(self):
+        """Payslip за межами кварталу не потрапляє в звіт."""
+        # Q1 payslip
+        self._create_payslip(self.emp1, date(2025, 1, 1), date(2025, 1, 31),
+                            gross=10000, pdfo=1800, military=500,
+                            esv_base=10000, esv=2200)
+        # Q2 payslip
+        self._create_payslip(self.emp1, date(2025, 4, 1), date(2025, 4, 30),
+                            gross=20000, pdfo=3600, military=1000,
+                            esv_base=20000, esv=4400)
+        rec_q1 = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        rec_q1.action_generate()
+        self.assertAlmostEqual(rec_q1.total_accrued, 10000, places=2)
+        self.assertEqual(len(rec_q1.line_4df_ids), 1)
+
+    def test_draft_payslips_excluded(self):
+        """Payslip у стані draft не потрапляє в звіт."""
+        self._create_payslip(self.emp1, date(2025, 1, 1), date(2025, 1, 31),
+                            gross=10000, pdfo=1800, military=500,
+                            esv_base=10000, esv=2200)
+        # Draft payslip — не повинен потрапити
+        slip = self._create_payslip(self.emp1, date(2025, 2, 1), date(2025, 2, 28),
+                            gross=20000, pdfo=3600, military=1000,
+                            esv_base=20000, esv=4400)
+        slip.state = 'draft'
+
+        rec = self.env['l10n_ua.tax.4df'].create({
+            'year': 2025, 'quarter': '1',
+        })
+        rec.action_generate()
+        # Тільки перший payslip
+        emp1_line = rec.line_4df_ids
+        self.assertEqual(len(emp1_line), 1)
+        self.assertAlmostEqual(emp1_line.accrued_amount, 10000, places=2)

--- a/l10n_ua_tax_4df/views/l10n_ua_tax_4df_views.xml
+++ b/l10n_ua_tax_4df/views/l10n_ua_tax_4df_views.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Form -->
+    <record id="l10n_ua_tax_4df_view_form" model="ir.ui.view">
+        <field name="name">l10n_ua.tax.4df.form</field>
+        <field name="model">l10n_ua.tax.4df</field>
+        <field name="arch" type="xml">
+            <form string="4ДФ">
+                <header>
+                    <button name="action_generate" string="Згенерувати"
+                            type="object" class="btn-primary"
+                            invisible="state == 'submitted'"
+                            confirm="Згенерувати рядки з payslips? Існуючі дані буде перезаписано."/>
+                    <button name="action_generate_xml" string="Сформувати XML"
+                            type="object" class="btn-secondary"
+                            invisible="state == 'draft'"/>
+                    <button name="action_submit" string="Подано"
+                            type="object" class="btn-primary"
+                            invisible="state != 'generated'"/>
+                    <button name="action_draft" string="Повернути в чернетку"
+                            type="object"
+                            invisible="state == 'draft'"/>
+                    <field name="state" widget="statusbar"
+                           statusbar_visible="draft,generated,submitted"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" readonly="1"/></h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="year" readonly="state != 'draft'"/>
+                            <field name="quarter" readonly="state != 'draft'"/>
+                            <field name="form_code" readonly="state != 'draft'"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                            <field name="currency_id" invisible="1"/>
+                        </group>
+                        <group>
+                            <field name="submission_date" readonly="1"
+                                   invisible="not submission_date"/>
+                            <field name="xml_filename" readonly="1"
+                                   invisible="not xml_filename"/>
+                            <field name="xml_file" filename="xml_filename"
+                                   readonly="1" invisible="not xml_file"/>
+                        </group>
+                    </group>
+                    <group string="Підсумки">
+                        <group>
+                            <field name="total_employees"/>
+                            <field name="total_accrued"/>
+                        </group>
+                        <group>
+                            <field name="total_pdfo"/>
+                            <field name="total_military"/>
+                            <field name="total_esv_base"/>
+                            <field name="total_esv"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Додаток 4ДФ (ПДФО/ВЗ)" name="t_4df">
+                            <field name="line_4df_ids" readonly="state == 'submitted'">
+                                <list editable="bottom">
+                                    <field name="employee_id"/>
+                                    <field name="rnokpp"/>
+                                    <field name="income_type"/>
+                                    <field name="income_sign"/>
+                                    <field name="accrued_amount" sum="Усього"/>
+                                    <field name="paid_amount"/>
+                                    <field name="pdfo_amount" sum="Усього ПДФО"/>
+                                    <field name="military_amount" sum="Усього ВЗ"/>
+                                    <field name="date_hire" optional="show"/>
+                                    <field name="date_termination" optional="show"/>
+                                    <field name="currency_id" column_invisible="1"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Додаток 1 (ЄСВ)" name="t1">
+                            <field name="line_t1_ids" readonly="state == 'submitted'">
+                                <list editable="bottom">
+                                    <field name="employee_id"/>
+                                    <field name="rnokpp"/>
+                                    <field name="accrued_amount" sum="Нараховано"/>
+                                    <field name="esv_base" sum="База ЄСВ"/>
+                                    <field name="esv_amount" sum="ЄСВ"/>
+                                    <field name="months_count"/>
+                                    <field name="currency_id" column_invisible="1"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Примітки" name="notes">
+                            <field name="notes"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- List -->
+    <record id="l10n_ua_tax_4df_view_list" model="ir.ui.view">
+        <field name="name">l10n_ua.tax.4df.list</field>
+        <field name="model">l10n_ua.tax.4df</field>
+        <field name="arch" type="xml">
+            <list string="4ДФ"
+                  decoration-info="state == 'draft'"
+                  decoration-warning="state == 'generated'"
+                  decoration-success="state == 'submitted'">
+                <field name="name"/>
+                <field name="year"/>
+                <field name="quarter"/>
+                <field name="form_code"/>
+                <field name="total_employees"/>
+                <field name="total_accrued" sum="Усього"/>
+                <field name="total_pdfo" sum="ПДФО"/>
+                <field name="total_military" sum="ВЗ"/>
+                <field name="total_esv" sum="ЄСВ"/>
+                <field name="submission_date"/>
+                <field name="state" widget="badge"
+                       decoration-info="state == 'draft'"
+                       decoration-warning="state == 'generated'"
+                       decoration-success="state == 'submitted'"/>
+                <field name="currency_id" column_invisible="1"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Search -->
+    <record id="l10n_ua_tax_4df_view_search" model="ir.ui.view">
+        <field name="name">l10n_ua.tax.4df.search</field>
+        <field name="model">l10n_ua.tax.4df</field>
+        <field name="arch" type="xml">
+            <search string="4ДФ">
+                <field name="year"/>
+                <field name="quarter"/>
+                <filter string="Чернетки" name="filter_draft"
+                        domain="[('state', '=', 'draft')]"/>
+                <filter string="Згенеровано" name="filter_generated"
+                        domain="[('state', '=', 'generated')]"/>
+                <filter string="Подано" name="filter_submitted"
+                        domain="[('state', '=', 'submitted')]"/>
+                <group>
+                    <filter string="Рік" name="groupby_year" domain="[]"
+                            context="{'group_by': 'year'}"/>
+                    <filter string="Стан" name="groupby_state" domain="[]"
+                            context="{'group_by': 'state'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="l10n_ua_tax_4df_action" model="ir.actions.act_window">
+        <field name="name">4ДФ</field>
+        <field name="res_model">l10n_ua.tax.4df</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="l10n_ua_tax_4df_view_search"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">Створіть перший звіт 4ДФ</p>
+            <p>
+                Об'єднана квартальна звітність з ПДФО/ВЗ/ЄСВ. Замінила
+                1ДФ та Д5 з 01.01.2021. Форма J0501T01 (юрособа) / F0501T01 (ФОП).
+            </p>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ua_tax_4df/views/menu_views.xml
+++ b/l10n_ua_tax_4df/views/menu_views.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <menuitem id="menu_l10n_ua_tax_4df"
+              name="4DF Reports"
+              parent="l10n_ua_account_base.menu_l10n_ua_accounting"
+              action="l10n_ua_tax_4df_action"
+              sequence="60"
+              groups="account.group_account_user"/>
+
+</odoo>


### PR DESCRIPTION
## Опис

Новий модуль **`l10n_ua_tax_4df`** — квартальний звіт 4ДФ, заміна 1ДФ і Д5 з 01.01.2021.

Closes #77

### Чому в `l10n_ua_tax_*`, а не в `l10n_ua_hr_*`

4ДФ — регламентний бухгалтерський звіт що подається бухгалтерами через М.Е.Doc / FREDO / Кабінет ДПС. `l10n_ua_hr_*` модулі — про операційний кадровий блок (особові картки, переміщення, відпустки, накази). `hr_salary` тут лише джерело даних: payslip aggregation.

Модуль ставиться поруч з `l10n_ua_tax_F0103309` (Декларація єдиного податку) — той самий клас регламентних звітів.

## Моделі

- **`l10n_ua.tax.4df`** — заголовок: year, quarter, form_code (J0501T01 для юрособи / F0501T01 для ФОП), стан, проводки
- **`l10n_ua.tax.4df.line.4df`** — Додаток 4ДФ: per-person ПДФО/ВЗ (наступник 1ДФ)
- **`l10n_ua.tax.4df.line.t1`** — Додаток 1: ЄСВ summary per person

Unique constraint на `(year, quarter, company_id)`.

## Workflow

`draft → generated → submitted`

1. Створити документ (рік + квартал)
2. **«Згенерувати»** → агрегує `hr.payslip` за квартал по працівнику:
   - 4ДФ: `accrued` (gross_salary), `pdfo_amount`, `military_tax_amount`, дата прийому/звільнення в межах кварталу
   - Дод. 1: `accrued`, `esv_base`, `esv_amount`, кількість унікальних місяців з payslip
3. **«Сформувати XML»** → будує базову XML-структуру (`<DECLAR>` + `<DECLARHEAD>` + `<DECLARBODY>` з двома `<T1RXXXX>` секціями)
4. **«Подано»** → фіксує submission_date

## Меню

`Bookkeeping (l10n_ua_account_base.menu_l10n_ua_accounting)` → **4DF Reports**

## Тестування

13 тестів, 0 failed:
- creation + name
- unique period+company constraint
- обчислення кварталу (Q1 = 1.01–31.03, Q4 = 1.10–31.12)
- агрегація per employee (2 payslips для emp1 → один сумований рядок)
- totals (employees, accrued, pdfo, military, esv)
- XML export (RNOKPP, sums у файлі)
- submit workflow + draft reset
- regenerate blocked after submission
- form_code default
- виключення payslips інших кварталів
- виключення draft payslips

## TODO (окремі PR)

- Додаток 5 (insured persons report — D1 successor)
- Додаток 6 (hazardous workers — D6 successor)
- Повна XSD-валідація J0501T01 / F0501T01 за специфікацією ДПС
- Інтеграція з `l10n_ua.tax.document` framework + KEP-підпис через `l10n_ua_tax_cabinet`

## Test plan

- [x] `odoo -i l10n_ua_tax_4df --test-enable` — 13 passed
- [ ] Створити quarterly payslips, згенерувати звіт, перевірити аґреговані суми
- [ ] Експортувати XML, відкрити в text-editor — перевірити структуру
- [ ] Подати → перевірити статус, неможливість редагування

🤖 Generated with [Claude Code](https://claude.com/claude-code)