### PR TITLE
feat: (l10n_ua_hr_documents) підтримка режиму мультикомпанійності для звіту "Накази по персоналу"

### DIFF
--- a/l10n_ua_hr_documents/__manifest__.py
+++ b/l10n_ua_hr_documents/__manifest__.py
@@ -30,6 +30,7 @@ Requires l10n_ua_hr_base module.
     ],
     'data': [
         'security/ir.model.access.csv',
+        'security/hr_order_security.xml',
         'data/ir_sequence_data.xml',
         'data/hr_order_type_data.xml',
         'data/hr_order_template_data.xml',

--- a/l10n_ua_hr_documents/models/hr_order.py
+++ b/l10n_ua_hr_documents/models/hr_order.py
@@ -134,7 +134,7 @@ class HrOrder(models.Model):
         ('cancelled', 'Cancelled'),
     ], string='Status', default='draft', tracking=True)
 
-    company_id = fields.Many2one('res.company', string='Company',
+    company_id = fields.Many2one('res.company', string='Company', required=True, index=True,
                                   default=lambda self: self.env.company)
 
     @api.model_create_multi

--- a/l10n_ua_hr_documents/security/hr_order_security.xml
+++ b/l10n_ua_hr_documents/security/hr_order_security.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="hr_order_company_rule" model="ir.rule">
+            <field name="name">HR Order: multi-company</field>
+            <field name="model_id" ref="model_hr_order"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">
+                ['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/l10n_ua_hr_documents/views/hr_order_views.xml
+++ b/l10n_ua_hr_documents/views/hr_order_views.xml
@@ -12,6 +12,7 @@
                 <field name="employee_id"/>
                 <field name="subject"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state == 'confirmed'" decoration-danger="state == 'cancelled'"/>
+                <field name="company_id" groups="base.group_multi_company" optional="hide"/>
             </list>
         </field>
     </record>
@@ -37,7 +38,7 @@
                             <field name="subject"/>
                         </group>
                         <group>
-                            <field name="company_id" invisible="1"/>
+                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                             <field name="employee_id"
                                    domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]"/>
                             <field name="department_id"


### PR DESCRIPTION
## Опис проблеми

Звіт **Документи → Накази по персоналу** (меню `menu_hr_order`, action `action_hr_order`, модель `hr.order`) не підтримував мультикомпанійний режим: користувач бачив усі накази по всіх компаніях незалежно від набору компаній, вибраних у перемикачі компаній (верхній правий кут інтерфейсу).

Поле `company_id` на моделі вже існувало, але:
- не було record rule, яке фільтрує записи за `company_ids` з контексту;
- поле було необов'язковим — допускалися записи без компанії;
- у формі поле було приховане (`invisible="1"`), у списку та search view взагалі відсутнє.

## Зміни

| Файл | Зміна |
| --- | --- |
| `l10n_ua_hr_documents/security/hr_order_security.xml` *(новий)* | Глобальне `ir.rule` `hr_order_company_rule` з `domain_force = ['\|', ('company_id', '=', False), ('company_id', 'in', company_ids)]` — фільтрує `hr.order` за компаніями, вибраними у перемикачі. |
| `l10n_ua_hr_documents/__manifest__.py` | Зареєстровано новий security-файл одразу після `ir.model.access.csv`. |
| `l10n_ua_hr_documents/models/hr_order.py` | `company_id` → `required=True, index=True`. Гарантує, що нові накази завжди отримують компанію, та прискорює фільтрацію record rule. |
| `l10n_ua_hr_documents/views/hr_order_views.xml` | У `list` додано колонку `company_id` (`groups="base.group_multi_company"`, `optional="hide"` — за замовчуванням прихована, користувач вмикає опціонально). У формі замість `invisible="1"` стоїть `groups="base.group_multi_company"` — поле видно лише при мультикомпанійному режимі. |

## Поведінка після змін

- Користувач у перемикачі справа вгорі вибирає компанії `A` і `B` → у списку **Документи → Накази по персоналу** бачить лише накази з `company_id ∈ {A, B}`.
- При створенні нового наказу `company_id` автоматично проставляється з `self.env.company` (default уже був, поведінку не змінено) і тепер обов'язкове.
- Старі записи з порожнім `company_id` (якщо такі є з історії) лишаються видимими всім — гілка `('company_id', '=', False)` у domain_force зроблена навмисно як м'яка міграція. Якщо в БД таких записів немає або їх треба заповнити — це окрема міграційна задача.
- У single-company режимі поведінка не змінюється: колонка та поле приховані через `base.group_multi_company`.

