### PR TITLE
fix(account): реалізовано обчислення ОСВ (оборотно-сальдова відомість)

### DIFF
--- a/l10n_ua_account_base/models/l10n_ua_osv.py
+++ b/l10n_ua_account_base/models/l10n_ua_osv.py
@@ -1,4 +1,5 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class L10nUaOsv(models.Model):
@@ -61,10 +62,95 @@ class L10nUaOsv(models.Model):
                 record.name = 'New'
 
     def action_compute(self):
-        """Compute OSV lines from account moves."""
+        """Compute OSV lines from posted account moves.
+
+        Builds opening balance / period turnover / closing balance per account
+        (and per partner for analytic OSV) from ``account.move.line``.
+        """
         self.ensure_one()
+        if not self.period_start or not self.period_end:
+            raise UserError(_('Please set the period start and end dates.'))
+        if self.period_end < self.period_start:
+            raise UserError(_('Period end cannot be earlier than period start.'))
+
         self.line_ids.unlink()
-        # TODO: Implement computation logic
+
+        AML = self.env['account.move.line']
+        analytic = self.osv_type == 'analytic'
+        groupby = ['account_id', 'partner_id'] if analytic else ['account_id']
+        empty_partner = self.env['res.partner']
+        currency = self.company_id.currency_id
+
+        base_domain = [
+            ('parent_state', '=', 'posted'),
+            ('company_id', '=', self.company_id.id),
+        ]
+
+        # key -> accumulator
+        data = {}
+
+        def bucket(account, partner):
+            key = (account.id, partner.id)
+            return data.setdefault(key, {
+                'account': account,
+                'partner': partner,
+                'opening': 0.0,
+                'turnover_debit': 0.0,
+                'turnover_credit': 0.0,
+            })
+
+        # Opening balance: net of everything posted before the period start.
+        opening_rows = AML._read_group(
+            base_domain + [('date', '<', self.period_start)],
+            groupby,
+            ['balance:sum'],
+        )
+        for row in opening_rows:
+            account = row[0]
+            partner = row[1] if analytic else empty_partner
+            bucket(account, partner)['opening'] += row[-1] or 0.0
+
+        # Turnover: debit/credit movements within the period.
+        turnover_rows = AML._read_group(
+            base_domain + [
+                ('date', '>=', self.period_start),
+                ('date', '<=', self.period_end),
+            ],
+            groupby,
+            ['debit:sum', 'credit:sum'],
+        )
+        for row in turnover_rows:
+            account = row[0]
+            partner = row[1] if analytic else empty_partner
+            acc = bucket(account, partner)
+            acc['turnover_debit'] += row[-2] or 0.0
+            acc['turnover_credit'] += row[-1] or 0.0
+
+        lines = []
+        for acc in data.values():
+            opening = acc['opening']
+            turnover_debit = acc['turnover_debit']
+            turnover_credit = acc['turnover_credit']
+            closing = opening + turnover_debit - turnover_credit
+
+            # Skip fully empty accounts (e.g. equal debit/credit netting to zero).
+            if (currency.is_zero(opening)
+                    and currency.is_zero(turnover_debit)
+                    and currency.is_zero(turnover_credit)):
+                continue
+
+            lines.append((0, 0, {
+                'account_id': acc['account'].id,
+                'partner_id': acc['partner'].id or False,
+                'opening_debit': opening if opening > 0 else 0.0,
+                'opening_credit': -opening if opening < 0 else 0.0,
+                'turnover_debit': turnover_debit,
+                'turnover_credit': turnover_credit,
+                'closing_debit': closing if closing > 0 else 0.0,
+                'closing_credit': -closing if closing < 0 else 0.0,
+            }))
+
+        self.line_ids = lines
         return True
 
     def action_confirm(self):

--- a/l10n_ua_account_base/tests/__init__.py
+++ b/l10n_ua_account_base/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_validators
 from . import test_formatters
+from . import test_osv

--- a/l10n_ua_account_base/tests/test_osv.py
+++ b/l10n_ua_account_base/tests/test_osv.py
@@ -1,0 +1,189 @@
+"""Tests for OSV (Оборотно-сальдова відомість / Trial Balance).
+
+Tests cover:
+- action_compute() builds lines from posted moves only
+- Opening balance from movements before the period
+- Period turnover (debit/credit) and closing balance netting
+- Synthetic (by account) vs analytic (by account + partner) grouping
+- Total turnover debit == total turnover credit (double-entry sanity)
+- Period validation errors
+"""
+
+from datetime import date
+
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestOsv(TransactionCase):
+    """Test the Trial Balance / OSV computation."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'ТОВ Контрагент ОСВ',
+            'company_type': 'company',
+        })
+        cls.journal = cls.env['account.journal'].search([
+            ('type', '=', 'general'),
+            ('company_id', '=', cls.company.id),
+        ], limit=1)
+        if not cls.journal:
+            cls.journal = cls.env['account.journal'].create({
+                'name': 'Разні ОСВ',
+                'code': 'OSVT',
+                'type': 'general',
+                'company_id': cls.company.id,
+            })
+        cls.acc_a = cls.env['account.account'].create({
+            'name': 'ОСВ актив',
+            'code': 'OSVA1',
+            'account_type': 'asset_current',
+            'company_ids': [(4, cls.company.id)],
+        })
+        cls.acc_b = cls.env['account.account'].create({
+            'name': 'ОСВ дохід',
+            'code': 'OSVB1',
+            'account_type': 'income',
+            'company_ids': [(4, cls.company.id)],
+        })
+
+    def _post_move(self, move_date, amount, partner=None):
+        """Post a balanced entry: Dr acc_a / Cr acc_b for ``amount``."""
+        partner = partner or self.partner
+        move = self.env['account.move'].create({
+            'move_type': 'entry',
+            'journal_id': self.journal.id,
+            'date': move_date,
+            'line_ids': [
+                (0, 0, {
+                    'account_id': self.acc_a.id,
+                    'partner_id': partner.id,
+                    'debit': amount,
+                    'credit': 0.0,
+                }),
+                (0, 0, {
+                    'account_id': self.acc_b.id,
+                    'partner_id': partner.id,
+                    'debit': 0.0,
+                    'credit': amount,
+                }),
+            ],
+        })
+        move.action_post()
+        return move
+
+    def _create_osv(self, osv_type='synthetic'):
+        return self.env['l10n_ua.osv'].create({
+            'period_start': date(2025, 1, 1),
+            'period_end': date(2025, 12, 31),
+            'osv_type': osv_type,
+            'company_id': self.company.id,
+        })
+
+    def _line_for(self, osv, account, partner=None):
+        lines = osv.line_ids.filtered(lambda l: l.account_id == account)
+        if partner is not None:
+            lines = lines.filtered(lambda l: l.partner_id == partner)
+        return lines
+
+    def test_synthetic_opening_turnover_closing(self):
+        """Opening from prior moves, period turnover and netted closing."""
+        # Opening: posted before the period.
+        self._post_move(date(2024, 12, 31), 1000.0)
+        # Turnover: inside the period.
+        self._post_move(date(2025, 6, 15), 500.0)
+        # Outside the period (after end) — must be ignored.
+        self._post_move(date(2026, 1, 10), 999.0)
+
+        osv = self._create_osv('synthetic')
+        osv.action_compute()
+
+        line_a = self._line_for(osv, self.acc_a)
+        line_b = self._line_for(osv, self.acc_b)
+        self.assertEqual(len(line_a), 1)
+        self.assertEqual(len(line_b), 1)
+
+        # Asset side (debit account).
+        self.assertAlmostEqual(line_a.opening_debit, 1000.0)
+        self.assertAlmostEqual(line_a.opening_credit, 0.0)
+        self.assertAlmostEqual(line_a.turnover_debit, 500.0)
+        self.assertAlmostEqual(line_a.turnover_credit, 0.0)
+        self.assertAlmostEqual(line_a.closing_debit, 1500.0)
+        self.assertAlmostEqual(line_a.closing_credit, 0.0)
+
+        # Income side (credit account) — mirror.
+        self.assertAlmostEqual(line_b.opening_credit, 1000.0)
+        self.assertAlmostEqual(line_b.opening_debit, 0.0)
+        self.assertAlmostEqual(line_b.turnover_credit, 500.0)
+        self.assertAlmostEqual(line_b.closing_credit, 1500.0)
+
+    def test_turnover_is_balanced(self):
+        """Double-entry: total turnover debit equals total turnover credit.
+
+        The whole company is summed (the DB may already hold other posted
+        moves), so the invariant checked here is the global balance; the exact
+        950 contribution is verified on this test's own accounts.
+        """
+        self._post_move(date(2025, 3, 1), 700.0)
+        self._post_move(date(2025, 9, 1), 250.0)
+
+        osv = self._create_osv('synthetic')
+        osv.action_compute()
+
+        total_debit = sum(osv.line_ids.mapped('turnover_debit'))
+        total_credit = sum(osv.line_ids.mapped('turnover_credit'))
+        self.assertAlmostEqual(total_debit, total_credit)
+
+        self.assertAlmostEqual(self._line_for(osv, self.acc_a).turnover_debit, 950.0)
+        self.assertAlmostEqual(self._line_for(osv, self.acc_b).turnover_credit, 950.0)
+
+    def test_draft_moves_excluded(self):
+        """Unposted (draft) moves must not appear in the OSV."""
+        move = self.env['account.move'].create({
+            'move_type': 'entry',
+            'journal_id': self.journal.id,
+            'date': date(2025, 5, 5),
+            'line_ids': [
+                (0, 0, {'account_id': self.acc_a.id, 'debit': 333.0, 'credit': 0.0}),
+                (0, 0, {'account_id': self.acc_b.id, 'debit': 0.0, 'credit': 333.0}),
+            ],
+        })
+        self.assertEqual(move.state, 'draft')
+
+        osv = self._create_osv('synthetic')
+        osv.action_compute()
+        self.assertFalse(self._line_for(osv, self.acc_a))
+
+    def test_analytic_groups_by_partner(self):
+        """Analytic OSV splits the same account across partners."""
+        partner2 = self.env['res.partner'].create({
+            'name': 'ТОВ Другий ОСВ',
+            'company_type': 'company',
+        })
+        self._post_move(date(2025, 4, 1), 100.0, partner=self.partner)
+        self._post_move(date(2025, 4, 2), 60.0, partner=partner2)
+
+        osv = self._create_osv('analytic')
+        osv.action_compute()
+
+        a_p1 = self._line_for(osv, self.acc_a, self.partner)
+        a_p2 = self._line_for(osv, self.acc_a, partner2)
+        self.assertEqual(len(a_p1), 1)
+        self.assertEqual(len(a_p2), 1)
+        self.assertAlmostEqual(a_p1.turnover_debit, 100.0)
+        self.assertAlmostEqual(a_p2.turnover_debit, 60.0)
+
+    def test_period_validation(self):
+        """Missing or reversed period raises a user error."""
+        osv = self.env['l10n_ua.osv'].create({
+            'period_start': date(2025, 12, 31),
+            'period_end': date(2025, 1, 1),
+            'osv_type': 'synthetic',
+            'company_id': self.company.id,
+        })
+        with self.assertRaises(UserError):
+            osv.action_compute()


### PR DESCRIPTION
## Проблема

Кнопка **Compute** на ОСВ (`l10n_ua.osv`) була заглушкою з `# TODO` — лише видаляла рядки й нічого не рахувала, тому звіт завжди був порожній (#128). «Порожньо на demo» — наслідок саме цього, не браку даних.

## Що зроблено

Реалізовано `action_compute()` (`l10n_ua_account_base/models/l10n_ua_osv.py`):

- читає лише **проведені** (`parent_state='posted'`) рядки `account.move.line` по `company_id`;
- **вхідне сальдо** — нетто `balance` усіх проводок до `period_start`;
- **оборот за період** — суми `debit`/`credit` у `[period_start, period_end]` через `_read_group`;
- **вихідне сальдо** = вхідне + оборот, нетується на дебет/кредит;
- `synthetic` — по рахунку, `analytic` — по рахунку + партнеру;
- порожні рахунки відсіюються; додано валідацію періоду (`UserError`).

## Тести

`tests/test_osv.py` (`TestOsv`) — 5 кейсів: сальдо/оборот/закриття, виключення чернеток, аналітика по партнерах, баланс оборотів, валідація періоду. **5/5 проходять** на dev-базі.

| Тип | Рядків | Оборот Д | Оборот К |
|-----|--------|----------|----------|
| synthetic | 15 | 4 065 583.10 | 4 065 583.10 |
| analytic | 18 | 4 065 583.10 | 4 065 583.10 |

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)