### PR TITLE
fix(l10n_ua_accounting): не застосовувати UA-логіку до не-UA компаній

### DIFF
--- a/l10n_ua_accounting/models/account_journal.py
+++ b/l10n_ua_accounting/models/account_journal.py
@@ -37,10 +37,12 @@ class AccountJournal(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        """Create sequences for cash and bank journals."""
+        """Create sequences for cash and bank journals of Ukrainian companies."""
         journals = super().create(vals_list)
 
         for journal in journals:
+            if not journal.company_id._l10n_ua_is_ukrainian():
+                continue
             if journal.type == 'cash':
                 journal._create_ua_cash_sequences()
             elif journal.type == 'bank':
@@ -51,7 +53,7 @@ class AccountJournal(models.Model):
     def _create_ua_cash_sequences(self):
         """Create Ukrainian cash order sequences for this journal."""
         self.ensure_one()
-        if self.type != 'cash':
+        if self.type != 'cash' or not self.company_id._l10n_ua_is_ukrainian():
             return
 
         IrSequence = self.env['ir.sequence'].sudo()
@@ -79,7 +81,7 @@ class AccountJournal(models.Model):
     def _create_ua_bank_sequences(self):
         """Create Ukrainian payment order sequence for this bank journal."""
         self.ensure_one()
-        if self.type != 'bank':
+        if self.type != 'bank' or not self.company_id._l10n_ua_is_ukrainian():
             return
 
         if not self.ua_pd_sequence_id:

--- a/l10n_ua_accounting/models/account_payment.py
+++ b/l10n_ua_accounting/models/account_payment.py
@@ -119,15 +119,19 @@ class AccountPayment(models.Model):
 
     # --- Cash order computes ---
 
-    @api.depends('journal_id', 'journal_id.type')
+    @api.depends('journal_id', 'journal_id.type', 'company_id.country_id')
     def _compute_is_ua_cash_order(self):
         for payment in self:
-            payment.is_ua_cash_order = payment.journal_id.type == 'cash'
+            payment.is_ua_cash_order = (
+                payment.journal_id.type == 'cash'
+                and payment.company_id._l10n_ua_is_ukrainian()
+            )
 
-    @api.depends('payment_type', 'journal_id.type')
+    @api.depends('payment_type', 'journal_id.type', 'company_id.country_id')
     def _compute_ua_cash_order_type(self):
         for payment in self:
-            if payment.journal_id.type == 'cash':
+            if (payment.journal_id.type == 'cash'
+                    and payment.company_id._l10n_ua_is_ukrainian()):
                 if payment.payment_type == 'inbound':
                     payment.ua_cash_order_type = 'pko'
                 else:
@@ -137,40 +141,45 @@ class AccountPayment(models.Model):
 
     # --- Payment order computes ---
 
-    @api.depends('journal_id', 'journal_id.type', 'payment_type')
+    @api.depends('journal_id', 'journal_id.type', 'payment_type', 'company_id.country_id')
     def _compute_is_ua_payment_order(self):
         for payment in self:
             payment.is_ua_payment_order = (
                 payment.journal_id.type == 'bank'
                 and payment.payment_type == 'outbound'
+                and payment.company_id._l10n_ua_is_ukrainian()
             )
 
-    @api.depends('payment_type', 'journal_id.type')
+    @api.depends('payment_type', 'journal_id.type', 'company_id.country_id')
     def _compute_ua_payment_order_type(self):
         for payment in self:
-            if payment.journal_id.type == 'bank' and payment.payment_type == 'outbound':
+            if (payment.journal_id.type == 'bank'
+                    and payment.payment_type == 'outbound'
+                    and payment.company_id._l10n_ua_is_ukrainian()):
                 payment.ua_payment_order_type = 'pd'
             else:
                 payment.ua_payment_order_type = 'other'
 
     # --- Analytic distribution propagation ---
 
-    def _prepare_move_lines_per_type(self, write_off_line_vals=None, force_balance=None):
+    def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
         """Inject analytic_distribution into counterpart and write-off lines.
 
         Cash (liquidity) side does not get analytics — стаття руху грошових коштів
-        applies to the expense/income side of the cash transaction.
+        applies to the expense/income side of the cash transaction. Core returns a
+        flat list [liquidity, counterpart, *write_offs]; the liquidity line is the
+        one booked on the outstanding account.
         """
-        result = super()._prepare_move_lines_per_type(
+        line_vals_list = super()._prepare_move_line_default_vals(
             write_off_line_vals=write_off_line_vals, force_balance=force_balance,
         )
         if not self.analytic_distribution:
-            return result
-        for line_vals in result.get('counterpart_lines', []):
-            line_vals['analytic_distribution'] = dict(self.analytic_distribution)
-        for line_vals in result.get('write_off_lines', []):
+            return line_vals_list
+        for line_vals in line_vals_list:
+            if line_vals.get('account_id') == self.outstanding_account_id.id:
+                continue
             line_vals.setdefault('analytic_distribution', dict(self.analytic_distribution))
-        return result
+        return line_vals_list
 
     # --- Create with auto-sequencing ---
 
@@ -182,6 +191,11 @@ class AccountPayment(models.Model):
             if not journal_id:
                 continue
             journal = self.env['account.journal'].browse(journal_id)
+            company = journal.company_id
+            if vals.get('company_id'):
+                company = self.env['res.company'].browse(vals['company_id'])
+            if not company._l10n_ua_is_ukrainian():
+                continue
             payment_type = vals.get('payment_type', 'inbound')
 
             # Cash order number

--- a/l10n_ua_accounting/models/res_company.py
+++ b/l10n_ua_accounting/models/res_company.py
@@ -30,3 +30,14 @@ class ResCompany(models.Model):
         currency_field='currency_id',
         help='Максимально допустимий залишок готівки в касі на кінець робочого дня',
     )
+
+    def _l10n_ua_is_ukrainian(self):
+        """Whether Ukrainian accounting rules apply to this company.
+
+        The module may be installed in a database that also hosts companies of
+        other countries; UA-specific documents and checks must not touch them.
+
+        Tolerates an empty recordset: computes run on new records whose
+        company_id is not set yet.
+        """
+        return len(self) == 1 and self.country_id.code == 'UA'

--- a/l10n_ua_accounting/tests/__init__.py
+++ b/l10n_ua_accounting/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_service_act
 from . import test_period_closing
 from . import test_aging_report
 from . import test_balance_pnl
+from . import test_non_ua_company

--- a/l10n_ua_accounting/tests/common.py
+++ b/l10n_ua_accounting/tests/common.py
@@ -10,6 +10,9 @@ class AccountingTestCase(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.company = cls.env.company
+        # UA documents (ПКО/ВКО/ПД) are only generated for Ukrainian companies,
+        # so the test company must have the country set before journals are made.
+        cls.company.country_id = cls.env.ref('base.ua')
         cls.currency = cls.company.currency_id
 
         # Cash journal

--- a/l10n_ua_accounting/tests/test_cash_analytic.py
+++ b/l10n_ua_accounting/tests/test_cash_analytic.py
@@ -49,18 +49,28 @@ class TestCashAnalytic(AccountingTestCase):
         self.assertEqual(pko.analytic_distribution, distribution)
 
     def test_prepare_move_lines_propagates_to_counterpart(self):
-        """_prepare_move_lines_per_type injects distribution into counterpart, NOT liquidity."""
+        """_prepare_move_line_default_vals injects distribution into counterpart, NOT liquidity."""
         distribution = {str(self.analytic_account.id): 100.0}
         pko = self._create_pko(analytic_distribution=distribution)
-        lines_per_type = pko._prepare_move_lines_per_type()
-        for line_vals in lines_per_type['liquidity_lines']:
+        line_vals_list = pko._prepare_move_line_default_vals()
+
+        liquidity_vals = [
+            v for v in line_vals_list
+            if v.get('account_id') == pko.outstanding_account_id.id
+        ]
+        counterpart_vals = [
+            v for v in line_vals_list
+            if v.get('account_id') != pko.outstanding_account_id.id
+        ]
+        self.assertTrue(liquidity_vals, 'Expected a liquidity line')
+        self.assertTrue(counterpart_vals, 'Expected at least one counterpart line')
+
+        for line_vals in liquidity_vals:
             self.assertFalse(
                 line_vals.get('analytic_distribution'),
                 'Liquidity (cash) line must NOT carry analytic distribution',
             )
-        self.assertTrue(lines_per_type['counterpart_lines'],
-                        'Expected at least one counterpart line')
-        for line_vals in lines_per_type['counterpart_lines']:
+        for line_vals in counterpart_vals:
             self.assertEqual(
                 line_vals.get('analytic_distribution'), distribution,
                 'Counterpart line must carry analytic distribution from payment',
@@ -69,9 +79,29 @@ class TestCashAnalytic(AccountingTestCase):
     def test_prepare_move_lines_no_distribution(self):
         """Without analytic_distribution, lines stay clean."""
         pko = self._create_pko()
-        lines_per_type = pko._prepare_move_lines_per_type()
-        for line_vals in lines_per_type['liquidity_lines'] + lines_per_type['counterpart_lines']:
+        for line_vals in pko._prepare_move_line_default_vals():
             self.assertFalse(line_vals.get('analytic_distribution'))
+
+    def test_analytic_reaches_journal_items_after_post(self):
+        """End-to-end: the distribution must survive onto the posted account.move.line.
+
+        The unit tests above passed vacuously for a long time while the override
+        targeted a method that does not exist; assert on real journal items.
+        """
+        distribution = {str(self.analytic_account.id): 100.0}
+        pko = self._create_pko(analytic_distribution=distribution)
+        pko.action_post()
+
+        lines = pko.move_id.line_ids
+        self.assertTrue(lines, 'Posting must produce journal items')
+        liquidity = lines.filtered(lambda l: l.account_id == pko.outstanding_account_id)
+        counterpart = lines - liquidity
+
+        self.assertTrue(counterpart, 'Expected a counterpart journal item')
+        for line in counterpart:
+            self.assertEqual(line.analytic_distribution, distribution)
+        for line in liquidity:
+            self.assertFalse(line.analytic_distribution)
 
     def test_required_when_analytic_group_enabled(self):
         """If user has analytic_accounting group, posting PKO without distribution must fail."""

--- a/l10n_ua_accounting/tests/test_non_ua_company.py
+++ b/l10n_ua_accounting/tests/test_non_ua_company.py
@@ -1,0 +1,79 @@
+"""UA cash-order logic must not touch companies of other countries — issues #173, #174."""
+
+from odoo.tests import tagged
+from .common import AccountingTestCase
+
+
+@tagged('post_install', '-at_install')
+class TestNonUaCompany(AccountingTestCase):
+    """A non-Ukrainian company sharing the database gets no ПКО/ВКО/ПД treatment."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Create first, set the country after: passing country_id to create()
+        # makes base auto-install that country's l10n module mid-test.
+        cls.foreign_company = cls.env['res.company'].create({
+            'name': 'Test Bohemia s.r.o.',
+        })
+        cls.foreign_company.country_id = cls.env.ref('base.cz')
+        cls.env.user.company_ids = [(4, cls.foreign_company.id)]
+        # A payment needs a chart of accounts; any non-UA one proves the point.
+        cls.env['account.chart.template'].with_company(cls.foreign_company).try_loading(
+            'generic_coa', company=cls.foreign_company, install_demo=False)
+        cls.foreign_cash_journal = cls.env['account.journal'].create({
+            'name': 'Pokladna',
+            'code': 'CSHF',
+            'type': 'cash',
+            'company_id': cls.foreign_company.id,
+        })
+        cls.foreign_bank_journal = cls.env['account.journal'].create({
+            'name': 'Banka',
+            'code': 'BNKF',
+            'type': 'bank',
+            'company_id': cls.foreign_company.id,
+        })
+        cls.foreign_partner = cls.env['res.partner'].create({'name': 'Zákazník Praha'})
+
+    def _create_foreign_payment(self, payment_type='inbound', journal=None):
+        return self.env['account.payment'].with_company(self.foreign_company).create({
+            'payment_type': payment_type,
+            'partner_type': 'customer',
+            'partner_id': self.foreign_partner.id,
+            'amount': 500,
+            'journal_id': (journal or self.foreign_cash_journal).id,
+            'company_id': self.foreign_company.id,
+        })
+
+    def test_no_ua_sequences_on_foreign_journals(self):
+        """Creating journals for a foreign company must not build ПКО/ВКО/ПД sequences."""
+        self.assertFalse(self.foreign_cash_journal.ua_pko_sequence_id)
+        self.assertFalse(self.foreign_cash_journal.ua_vko_sequence_id)
+        self.assertFalse(self.foreign_bank_journal.ua_pd_sequence_id)
+
+    def test_ua_sequences_still_created_for_ua_company(self):
+        """The Ukrainian company keeps its sequences — the guard must not over-reach."""
+        self.assertTrue(self.cash_journal.ua_pko_sequence_id)
+        self.assertTrue(self.cash_journal.ua_vko_sequence_id)
+        self.assertTrue(self.bank_journal.ua_pd_sequence_id)
+
+    def test_foreign_payment_is_not_a_ua_cash_order(self):
+        payment = self._create_foreign_payment()
+        self.assertFalse(payment.is_ua_cash_order)
+        self.assertEqual(payment.ua_cash_order_type, 'other')
+        self.assertFalse(payment.ua_cash_order_number)
+
+    def test_foreign_bank_payment_is_not_a_ua_payment_order(self):
+        payment = self._create_foreign_payment(
+            payment_type='outbound', journal=self.foreign_bank_journal)
+        self.assertFalse(payment.is_ua_payment_order)
+        self.assertEqual(payment.ua_payment_order_type, 'other')
+        self.assertFalse(payment.ua_payment_order_number)
+
+    def test_foreign_cash_payment_posts_with_analytic_accounting_on(self):
+        """The regression from #173: posting raised a Ukrainian UserError."""
+        self.env.user.group_ids = [
+            (4, self.env.ref('analytic.group_analytic_accounting').id)]
+        payment = self._create_foreign_payment()
+        payment.action_post()
+        self.assertNotEqual(payment.state, 'draft')


### PR DESCRIPTION
Closes #173, closes #174, closes #179.

## Контекст

Перевірка можливості вести два обліки в одній базі Odoo 19: українська компанія (`ua_psbo`) поруч із чеською (`cz`). Архітектурно це штатний сценарій — `res.company.chart_template` задається на кожну компанію окремо, і плани рахунків ізолюються коректно (342 рахунки UA проти 283 CZ, спільних — **0**; накладні проводяться в UAH з ПДВ 20% і в CZK з DPH 21%).

Заважали не плани рахунків, а незагороджені перевизначення core-моделей у `l10n_ua_accounting`: **у жодному з модулів не було перевірки країни компанії**.

## Зміни

Додано `res.company._l10n_ua_is_ukrainian()` як єдину точку істини замість чотирьох окремих перевірок. Метод толерантний до порожнього recordset — компʼюти виконуються і на нових записах, де `company_id` ще не заповнений, і `ensure_one()` там кидав би помилку.

**#173** — `action_post` кидав українську `UserError` на касовому платежі *будь-якої* компанії при увімкненій групі аналітичного обліку, бо `is_ua_cash_order` визначався лише типом журналу. Гейт у компʼюті лікує заразом і raise, і видимість UA-полів у формі (`invisible="not is_ua_cash_order"`), тож правити XML не довелось. `@api.depends` розширено на `company_id.country_id`.

**#174** — журнали будь-якої компанії отримували послідовності `ПКО-`/`ВКО-`/`ПД-`, а платежі — відповідні номери.

**#179** — знайдено під час прогону тестів. Override цілився в `_prepare_move_lines_per_type`, якого не існує в Odoo 19: ядро має `_prepare_move_line_default_vals` і повертає плаский список `[liquidity, counterpart, *write_offs]`, а не словник. Тому аналітичний розподіл **ніколи не потрапляв на рядки проводки** — тобто функція, заради якої вводився `analytic_distribution`, мовчки не працювала. Іронічно, що #173 карав користувача за незаповнену аналітику, яка потім усе одно нікуди не проставлялась.

## Тести

`0 failed, 0 error(s) of 63 tests`

- `tests/common.py`: тестова компанія тепер явно UA — без цього гейт вимкнув би наявні перевірки ПКО/ВКО.
- `tests/test_non_ua_company.py` (новий, 5 тестів): чеська компанія не отримує UA-послідовностей, її платежі не є ПКО/ВКО/ПД, і касовий платіж проводиться при увімкненому аналітичному обліку.
- `tests/test_cash_analytic.py`: два тести переписано під плаский список; додано наскрізний `test_analytic_reaches_journal_items_after_post`, який перевіряє `account.move.line` уже після проведення.

Старі тести падали з `AttributeError`, а не з assert — такий тест ніколи не торкався справжньої поведінки, тому баг прожив із травня (`b7dfae26`). Щоб переконатись, що нові тести дійсно щось ловлять, я тимчасово повернув зламану назву методу: результат — `FAIL` (assert про поведінку), а не `ERROR`.

## Що лишається окремо

Косметика (#178) і ручні шляхи (#175, #176, #177) цим PR не зачеплені.

🤖 Generated with [Claude Code](https://claude.com/claude-code)