### PR TITLE
fix(l10n_ua_bank_currency_sync): крос-курс через гривню для не-UAH компаній

### DIFF
--- a/l10n_ua_bank_currency_sync/models/res_currency_rate_provider.py
+++ b/l10n_ua_bank_currency_sync/models/res_currency_rate_provider.py
@@ -120,6 +120,47 @@ class ResCurrencyRateProvider(models.Model):
         self.last_sync_date = fields.Datetime.now()
         return result
 
+    # --- Cross-rate helpers ---
+
+    def _uah_per_company_unit(self, uah_rates):
+        """How many UAH one unit of the company currency is worth.
+
+        Ukrainian banks quote every currency against the hryvnia, so a company
+        keeping its books in another currency needs a cross-rate through UAH.
+        `uah_rates` maps a currency code to UAH per one unit of that currency.
+
+        Returns None when the company currency is not quoted by this provider:
+        no cross-rate can be derived, and writing the raw UAH quote instead
+        would silently corrupt res.currency.rate.
+        """
+        self.ensure_one()
+        code = self.company_id.currency_id.name
+        if code == 'UAH':
+            return 1.0
+        rate = uah_rates.get(code)
+        return rate if rate else None
+
+    def _rate_vals(self, uah_per_unit, uah_per_company_unit):
+        """Odoo rate vals for a currency quoted at `uah_per_unit` UAH.
+
+        Odoo stores `rate` as the number of units of the currency bought by one
+        unit of the company currency; `inverse_company_rate` is its reciprocal.
+        """
+        return {
+            'rate': uah_per_company_unit / uah_per_unit,
+            'inverse_company_rate': uah_per_unit / uah_per_company_unit,
+        }
+
+    def _log_missing_company_quote(self, provider_label):
+        self.ensure_one()
+        _logger.warning(
+            "%s provider %r: company currency %s is not quoted against UAH by this "
+            "provider, so no cross-rate can be computed. Skipping rate sync for "
+            "company %s.",
+            provider_label, self.display_name,
+            self.company_id.currency_id.name, self.company_id.display_name,
+        )
+
     def _sync_nbu_rates(self, target_date):
         """Sync rates from National Bank of Ukraine.
 
@@ -155,27 +196,30 @@ class ResCurrencyRateProvider(models.Model):
         sync_currencies = self.currency_ids or Currency.search([('active', 'in', [True, False])])
         sync_codes = {c.name: c for c in sync_currencies}
 
-        for item in data:
-            currency_code = item.get('cc')
-            rate = item.get('rate')
+        # NBU quotes: 1 foreign = X UAH
+        uah_rates = {
+            item['cc']: item['rate']
+            for item in data
+            if item.get('cc') and item.get('rate')
+        }
+        uah_per_company_unit = self._uah_per_company_unit(uah_rates)
+        if not uah_per_company_unit:
+            self._log_missing_company_quote('NBU')
+            return {'created': 0, 'updated': 0, 'skipped': len(uah_rates)}
 
-            if not currency_code or not rate:
-                continue
+        company_currency = self.company_id.currency_id
 
+        for currency_code, rate in uah_rates.items():
             currency = sync_codes.get(currency_code)
             if not currency:
                 skipped += 1
                 continue
 
-            # NBU rate is: 1 foreign = X UAH
-            # Odoo rate should be: 1 company_currency = X foreign
-            # If company currency is UAH: rate = 1 / nbu_rate
-            company_currency = self.company_id.currency_id
-            if company_currency.name == 'UAH':
-                odoo_rate = 1.0 / rate if rate else 0
-            else:
-                # If company currency is not UAH, we need cross-rate
-                odoo_rate = rate  # Simplified, may need adjustment
+            if currency == company_currency:
+                # A currency is always worth exactly one of itself.
+                continue
+
+            rate_vals = self._rate_vals(rate, uah_per_company_unit)
 
             # Check if rate exists for this date
             existing_rate = Rate.search([
@@ -185,18 +229,14 @@ class ResCurrencyRateProvider(models.Model):
             ], limit=1)
 
             if existing_rate:
-                existing_rate.write({
-                    'rate': odoo_rate,
-                    'inverse_company_rate': rate,
-                })
+                existing_rate.write(rate_vals)
                 updated += 1
             else:
                 Rate.create({
                     'currency_id': currency.id,
                     'name': target_date,
-                    'rate': odoo_rate,
-                    'inverse_company_rate': rate,
                     'company_id': self.company_id.id,
+                    **rate_vals,
                 })
                 created += 1
 
@@ -238,28 +278,36 @@ class ResCurrencyRateProvider(models.Model):
         sync_currencies = self.currency_ids or Currency.search([('active', 'in', [True, False])])
         sync_codes = {c.name: c for c in sync_currencies}
 
+        # PrivatBank quotes buy/sale; only pairs based on UAH are usable here.
+        uah_rates = {}
         for item in data:
             currency_code = item.get('ccy')
-            # PrivatBank provides buy and sale rates
+            base_ccy = item.get('base_ccy')
+            if not currency_code or (base_ccy and base_ccy != 'UAH'):
+                continue
             buy_rate = float(item.get('buy', 0))
             sale_rate = float(item.get('sale', 0))
-
-            if not currency_code or not buy_rate:
+            if not buy_rate:
                 continue
+            uah_rates[currency_code] = (buy_rate + sale_rate) / 2 if sale_rate else buy_rate
 
+        uah_per_company_unit = self._uah_per_company_unit(uah_rates)
+        if not uah_per_company_unit:
+            self._log_missing_company_quote('PrivatBank')
+            return {'created': 0, 'updated': 0, 'skipped': len(uah_rates)}
+
+        company_currency = self.company_id.currency_id
+
+        for currency_code, avg_rate in uah_rates.items():
             currency = sync_codes.get(currency_code)
             if not currency:
                 skipped += 1
                 continue
 
-            # Use average of buy/sale as the rate
-            avg_rate = (buy_rate + sale_rate) / 2 if sale_rate else buy_rate
+            if currency == company_currency:
+                continue
 
-            company_currency = self.company_id.currency_id
-            if company_currency.name == 'UAH':
-                odoo_rate = 1.0 / avg_rate if avg_rate else 0
-            else:
-                odoo_rate = avg_rate
+            rate_vals = self._rate_vals(avg_rate, uah_per_company_unit)
 
             existing_rate = Rate.search([
                 ('currency_id', '=', currency.id),
@@ -268,18 +316,14 @@ class ResCurrencyRateProvider(models.Model):
             ], limit=1)
 
             if existing_rate:
-                existing_rate.write({
-                    'rate': odoo_rate,
-                    'inverse_company_rate': avg_rate,
-                })
+                existing_rate.write(rate_vals)
                 updated += 1
             else:
                 Rate.create({
                     'currency_id': currency.id,
                     'name': target_date,
-                    'rate': odoo_rate,
-                    'inverse_company_rate': avg_rate,
                     'company_id': self.company_id.id,
+                    **rate_vals,
                 })
                 created += 1
 
@@ -322,29 +366,20 @@ class ResCurrencyRateProvider(models.Model):
         # Monobank returns pairs, we only want rates against UAH (980)
         uah_code = 980
 
+        uah_rates = {}
         for item in data:
-            currency_a = item.get('currencyCodeA')
-            currency_b = item.get('currencyCodeB')
-
             # Only process pairs where one side is UAH
-            if currency_b != uah_code:
+            if item.get('currencyCodeB') != uah_code:
                 continue
 
-            currency_code = MONO_CURRENCY_CODES.get(currency_a)
+            currency_code = MONO_CURRENCY_CODES.get(item.get('currencyCodeA'))
             if not currency_code:
                 skipped += 1
                 continue
 
-            currency = sync_codes.get(currency_code)
-            if not currency:
-                skipped += 1
-                continue
-
-            # Monobank provides rateBuy and rateSell
+            # Monobank provides rateBuy and rateSell; rateCross when it does not
             buy_rate = item.get('rateBuy', 0)
             sell_rate = item.get('rateSell', 0)
-
-            # Use rateCross if buy/sell not available
             if not buy_rate:
                 buy_rate = item.get('rateCross', 0)
             if not sell_rate:
@@ -354,13 +389,25 @@ class ResCurrencyRateProvider(models.Model):
                 skipped += 1
                 continue
 
-            avg_rate = (buy_rate + sell_rate) / 2 if sell_rate else buy_rate
+            uah_rates[currency_code] = (buy_rate + sell_rate) / 2 if sell_rate else buy_rate
 
-            company_currency = self.company_id.currency_id
-            if company_currency.name == 'UAH':
-                odoo_rate = 1.0 / avg_rate if avg_rate else 0
-            else:
-                odoo_rate = avg_rate
+        uah_per_company_unit = self._uah_per_company_unit(uah_rates)
+        if not uah_per_company_unit:
+            self._log_missing_company_quote('Monobank')
+            return {'created': 0, 'updated': 0, 'skipped': skipped + len(uah_rates)}
+
+        company_currency = self.company_id.currency_id
+
+        for currency_code, avg_rate in uah_rates.items():
+            currency = sync_codes.get(currency_code)
+            if not currency:
+                skipped += 1
+                continue
+
+            if currency == company_currency:
+                continue
+
+            rate_vals = self._rate_vals(avg_rate, uah_per_company_unit)
 
             existing_rate = Rate.search([
                 ('currency_id', '=', currency.id),
@@ -369,18 +416,14 @@ class ResCurrencyRateProvider(models.Model):
             ], limit=1)
 
             if existing_rate:
-                existing_rate.write({
-                    'rate': odoo_rate,
-                    'inverse_company_rate': avg_rate,
-                })
+                existing_rate.write(rate_vals)
                 updated += 1
             else:
                 Rate.create({
                     'currency_id': currency.id,
                     'name': target_date,
-                    'rate': odoo_rate,
-                    'inverse_company_rate': avg_rate,
                     'company_id': self.company_id.id,
+                    **rate_vals,
                 })
                 created += 1
 

--- a/l10n_ua_bank_currency_sync/tests/__init__.py
+++ b/l10n_ua_bank_currency_sync/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_cross_rate

--- a/l10n_ua_bank_currency_sync/tests/test_cross_rate.py
+++ b/l10n_ua_bank_currency_sync/tests/test_cross_rate.py
@@ -1,0 +1,133 @@
+"""Cross-rate through UAH for companies not keeping books in hryvnia — issue #177."""
+
+from datetime import date
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestCrossRate(TransactionCase):
+    """Ukrainian banks quote against UAH; a non-UAH company needs a cross-rate."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.date = date(2026, 7, 10)
+        cls.usd = cls.env.ref('base.USD')
+        cls.eur = cls.env.ref('base.EUR')
+        cls.uah = cls.env.ref('base.UAH')
+        cls.czk = cls.env.ref('base.CZK')
+        (cls.usd + cls.eur + cls.uah + cls.czk).write({'active': True})
+
+        # NBU quotes: 1 unit of the currency costs this many UAH.
+        cls.nbu_data = [
+            {'cc': 'USD', 'rate': 41.0},
+            {'cc': 'EUR', 'rate': 45.0},
+            {'cc': 'CZK', 'rate': 1.8},
+        ]
+
+    def _make_company(self, name, currency):
+        company = self.env['res.company'].create({'name': name})
+        company.currency_id = currency
+        return company
+
+    def _make_provider(self, company, code='nbu'):
+        return self.env['res.currency.rate.provider'].create({
+            'name': f'{code} for {company.name}',
+            'code': code,
+            'company_id': company.id,
+        })
+
+    def _rate(self, company, currency):
+        return self.env['res.currency.rate'].search([
+            ('currency_id', '=', currency.id),
+            ('company_id', '=', company.id),
+            ('name', '=', self.date),
+        ], limit=1)
+
+    def test_uah_company_rate_is_reciprocal(self):
+        """Unchanged behaviour for a Ukrainian company: rate = 1 / quote."""
+        company = self._make_company('UA Co', self.uah)
+        provider = self._make_provider(company)
+        result = provider._process_nbu_data(self.nbu_data, self.date)
+
+        self.assertEqual(result['created'], 3)
+        usd_rate = self._rate(company, self.usd)
+        self.assertAlmostEqual(usd_rate.rate, 1.0 / 41.0, places=9)
+        self.assertAlmostEqual(usd_rate.inverse_company_rate, 41.0, places=6)
+
+    def test_non_uah_company_gets_cross_rate(self):
+        """CZK company: 1 CZK = 1.8 UAH, 1 USD = 41 UAH → 1 CZK = 1.8/41 USD."""
+        company = self._make_company('CZ Co', self.czk)
+        provider = self._make_provider(company)
+        provider._process_nbu_data(self.nbu_data, self.date)
+
+        usd_rate = self._rate(company, self.usd)
+        self.assertAlmostEqual(usd_rate.rate, 1.8 / 41.0, places=9)
+        self.assertAlmostEqual(usd_rate.inverse_company_rate, 41.0 / 1.8, places=6)
+
+        eur_rate = self._rate(company, self.eur)
+        self.assertAlmostEqual(eur_rate.rate, 1.8 / 45.0, places=9)
+
+    def test_non_uah_company_does_not_get_raw_uah_quote(self):
+        """The #177 regression: the raw UAH quote was written as the rate."""
+        company = self._make_company('CZ Co raw', self.czk)
+        provider = self._make_provider(company)
+        provider._process_nbu_data(self.nbu_data, self.date)
+
+        usd_rate = self._rate(company, self.usd)
+        self.assertNotAlmostEqual(
+            usd_rate.rate, 41.0, places=6,
+            msg='Raw UAH quote must never be stored as the company rate',
+        )
+
+    def test_company_currency_itself_is_not_written(self):
+        """A currency is always worth one of itself; no rate row for CZK."""
+        company = self._make_company('CZ Co self', self.czk)
+        provider = self._make_provider(company)
+        provider._process_nbu_data(self.nbu_data, self.date)
+
+        self.assertFalse(self._rate(company, self.czk))
+
+    def test_unquoted_company_currency_writes_nothing(self):
+        """If the provider does not quote the company currency, skip — never guess."""
+        company = self._make_company('CZ Co unquoted', self.czk)
+        provider = self._make_provider(company)
+        data_without_czk = [d for d in self.nbu_data if d['cc'] != 'CZK']
+
+        result = provider._process_nbu_data(data_without_czk, self.date)
+
+        self.assertEqual(result['created'], 0)
+        self.assertEqual(result['updated'], 0)
+        self.assertFalse(self._rate(company, self.usd))
+        self.assertFalse(self._rate(company, self.eur))
+
+    def test_privat_ignores_non_uah_based_pairs(self):
+        """PrivatBank publishes non-UAH pairs; they must not pollute the rates."""
+        company = self._make_company('UA Co privat', self.uah)
+        provider = self._make_provider(company, code='privatbank')
+        data = [
+            {'ccy': 'USD', 'base_ccy': 'UAH', 'buy': '40.0', 'sale': '42.0'},
+            {'ccy': 'EUR', 'base_ccy': 'USD', 'buy': '1.1', 'sale': '1.2'},
+        ]
+        provider._process_privat_data(data, self.date)
+
+        usd_rate = self._rate(company, self.usd)
+        self.assertAlmostEqual(usd_rate.rate, 1.0 / 41.0, places=9)
+        self.assertFalse(self._rate(company, self.eur))
+
+    def test_mono_cross_rate(self):
+        """Monobank pairs against UAH (980) feed the same cross-rate maths."""
+        company = self._make_company('CZ Co mono', self.czk)
+        provider = self._make_provider(company, code='monobank')
+        data = [
+            {'currencyCodeA': 840, 'currencyCodeB': 980, 'rateBuy': 40.0, 'rateSell': 42.0},
+            {'currencyCodeA': 203, 'currencyCodeB': 980, 'rateBuy': 1.7, 'rateSell': 1.9},
+            {'currencyCodeA': 978, 'currencyCodeB': 840, 'rateCross': 1.1},
+        ]
+        provider._process_mono_data(data, self.date)
+
+        usd_rate = self._rate(company, self.usd)
+        self.assertAlmostEqual(usd_rate.rate, 1.8 / 41.0, places=9)
+        # EUR was only quoted against USD, never against UAH
+        self.assertFalse(self._rate(company, self.eur))


### PR DESCRIPTION
Closes #177.

## Проблема

Українські банки котирують валюти до гривні. Якщо валюта компанії не UAH, код брав сирий гривневий курс як курс Odoo:

```python
else:
    # If company currency is not UAH, we need cross-rate
    odoo_rate = rate  # Simplified, may need adjustment
```

Крон `_cron_sync_rates` ітерує **всі** провайдери з `auto_sync=True` без прив'язки до країни. Для чеської компанії (CZK) у `res.currency.rate` тихо записувались хибні курси — без винятку і без попередження. Мовчазне псування фінансових даних гірше за помилку на екрані, тому цей issue був підвищений над рештою косметики.

## Рішення

Курс рахується як крос через гривню:

```
rate = UAH_за_одиницю_валюти_компанії / UAH_за_одиницю_цієї_валюти
```

Для UAH-компанії чисельник дорівнює 1, і формула зводиться до наявної `1 / rate` — **поведінка для України не змінюється**, що закріплено окремим тестом.

Якщо провайдер не котирує валюту компанії (Privat і Mono публікують лише кілька валют), крос-курс вивести неможливо. Тепер нічого не пишеться і логується попередження — замість того, щоб вгадувати. Це головний принцип фікса: краще не записати курс, ніж записати неправильний.

Виправлено в усіх трьох провайдерах (NBU, PrivatBank, Monobank) через спільні хелпери `_uah_per_company_unit()` і `_rate_vals()`.

## Побічні знахідки

- Курс для валюти самої компанії більше не створюється — вона завжди дорівнює одиниці.
- Пари PrivatBank з `base_ccy != 'UAH'` (напр. EUR/USD) раніше потрапляли в курси так, ніби вони гривневі. Тепер відфільтровані.
- `inverse_company_rate` раніше писався як сирий гривневий курс і був неправильним для не-UAH компанії; тепер це справжня величина, обернена до `rate`.

## Тести

`0 failed, 0 error(s) of 7 tests` — новий пакет `tests/`, у модулі тестів не було.

Покрито: крос-курс для CZK-компанії, незмінна поведінка для UAH-компанії, відмова писати курси без котирування валюти компанії, ігнорування не-гривневих пар PrivatBank, крос-курс Monobank.

Щоб переконатись, що тести не зелені вхолосту, я тимчасово повернув `odoo_rate = rate`: три тести впали з `FAIL` (assert про поведінку), після відновлення — знову зелені.

🤖 Generated with [Claude Code](https://claude.com/claude-code)