### PR TITLE
refactor(l10n_ua_account_base): винести субконто hr.department у міст

### DIFF
--- a/l10n_ua_account_base/i18n/uk_UA.po
+++ b/l10n_ua_account_base/i18n/uk_UA.po
@@ -697,11 +697,6 @@ msgid "Product (Subconto)"
 msgstr "Номенклатура (субконто)"
 
 #. module: l10n_ua_account_base
-#: model:ir.model.fields,field_description:l10n_ua_account_base.field_account_move_line__subconto_department_id
-msgid "Department (Subconto)"
-msgstr "Підрозділ (субконто)"
-
-#. module: l10n_ua_account_base
 #: model_terms:ir.ui.view,arch_db:l10n_ua_account_base.view_account_form_subconto
 msgid "Subconto"
 msgstr "Субконто"

--- a/l10n_ua_account_base/models/l10n_ua_subconto.py
+++ b/l10n_ua_account_base/models/l10n_ua_subconto.py
@@ -210,37 +210,35 @@ class AccountMoveLine(models.Model):
         inverse='_inverse_subconto_product',
         store=True,
     )
-    subconto_department_id = fields.Many2one(
-        'hr.department',
-        string='Department (Subconto)',
-        compute='_compute_subconto_quick_fields',
-        inverse='_inverse_subconto_department',
-        store=True,
-    )
+    def _subconto_quick_fields_map(self):
+        """Map a subconto model name to its quick access field on this model.
+
+        A module bridging another domain (hr, stock, …) extends this map instead
+        of declaring a Many2one to a model that l10n_ua_account_base does not
+        depend on. See l10n_ua_account_subconto_hr for an example.
+        """
+        return {
+            'res.partner': 'subconto_partner_id',
+            'product.product': 'subconto_product_id',
+        }
 
     @api.depends('subconto_ids', 'subconto_ids.res_model', 'subconto_ids.res_id')
     def _compute_subconto_quick_fields(self):
+        quick_fields = self._subconto_quick_fields_map()
         for line in self:
-            line.subconto_partner_id = False
-            line.subconto_product_id = False
-            line.subconto_department_id = False
+            for field_name in quick_fields.values():
+                line[field_name] = False
 
             for sub in line.subconto_ids:
-                if sub.res_model == 'res.partner':
-                    line.subconto_partner_id = sub.res_id
-                elif sub.res_model == 'product.product':
-                    line.subconto_product_id = sub.res_id
-                elif sub.res_model == 'hr.department':
-                    line.subconto_department_id = sub.res_id
+                field_name = quick_fields.get(sub.res_model)
+                if field_name:
+                    line[field_name] = sub.res_id
 
     def _inverse_subconto_partner(self):
         self._set_subconto_value('res.partner', 'subconto_partner_id')
 
     def _inverse_subconto_product(self):
         self._set_subconto_value('product.product', 'subconto_product_id')
-
-    def _inverse_subconto_department(self):
-        self._set_subconto_value('hr.department', 'subconto_department_id')
 
     def _set_subconto_value(self, model_name, field_name):
         """Helper to set subconto value from quick access field"""

--- a/l10n_ua_account_base/views/l10n_ua_subconto_views.xml
+++ b/l10n_ua_account_base/views/l10n_ua_subconto_views.xml
@@ -168,10 +168,9 @@
                 <notebook position="inside">
                     <page string="Subconto" name="subconto">
                         <group>
-                            <group string="Quick Fields">
+                            <group string="Quick Fields" name="subconto_quick_fields">
                                 <field name="subconto_partner_id"/>
                                 <field name="subconto_product_id"/>
-                                <field name="subconto_department_id"/>
                             </group>
                         </group>
                         <separator string="All Subconto Values"/>

--- a/l10n_ua_account_subconto_hr/__init__.py
+++ b/l10n_ua_account_subconto_hr/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ua_account_subconto_hr/__manifest__.py
+++ b/l10n_ua_account_subconto_hr/__manifest__.py
@@ -1,0 +1,35 @@
+{
+    'name': 'Ukraine - Subconto: HR Departments',
+    'version': '19.0.1.0.0',
+    'category': 'Accounting/Localization',
+    'summary': 'Bridge: use HR departments as a subconto dimension',
+    'description': """
+Ukraine - Subconto: HR Departments
+==================================
+
+Bridge module between ``l10n_ua_account_base`` and ``hr``.
+
+Adds the HR department (Підрозділ) as an analytical dimension (субконто) on
+journal items:
+
+* ``l10n_ua.subconto.type`` record for ``hr.department``
+* ``subconto_department_id`` quick access field on ``account.move.line``
+
+The accounting base module stays free of any HR dependency; install this bridge
+only when departments should be usable as subconto.
+    """,
+    'author': 'Svyatoslav Nadozirny',
+    'website': 'https://many2one.online',
+    'license': 'LGPL-3',
+    'depends': [
+        'l10n_ua_account_base',
+        'hr',
+    ],
+    'data': [
+        'data/l10n_ua_subconto_data.xml',
+        'views/l10n_ua_subconto_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': True,
+}

--- a/l10n_ua_account_subconto_hr/data/l10n_ua_subconto_data.xml
+++ b/l10n_ua_account_subconto_hr/data/l10n_ua_subconto_data.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <!--
+        Subconto type for HR departments.
+
+        l10n_ua_account_base ships types only for the models it depends on;
+        this record is what makes subconto_department_id actually work.
+        -->
+        <record id="subconto_type_department" model="l10n_ua.subconto.type">
+            <field name="name">Departments</field>
+            <field name="code">DEPARTMENT</field>
+            <field name="sequence">50</field>
+            <field name="model_id" ref="hr.model_hr_department"/>
+            <field name="field_name">complete_name</field>
+            <field name="description">HR departments (Підрозділи)</field>
+        </record>
+
+    </data>
+</odoo>

--- a/l10n_ua_account_subconto_hr/models/__init__.py
+++ b/l10n_ua_account_subconto_hr/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move_line

--- a/l10n_ua_account_subconto_hr/models/account_move_line.py
+++ b/l10n_ua_account_subconto_hr/models/account_move_line.py
@@ -1,0 +1,24 @@
+"""HR department as a subconto dimension on journal items."""
+
+from odoo import models, fields
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    subconto_department_id = fields.Many2one(
+        'hr.department',
+        string='Department (Subconto)',
+        compute='_compute_subconto_quick_fields',
+        inverse='_inverse_subconto_department',
+        store=True,
+    )
+
+    def _subconto_quick_fields_map(self):
+        return {
+            **super()._subconto_quick_fields_map(),
+            'hr.department': 'subconto_department_id',
+        }
+
+    def _inverse_subconto_department(self):
+        self._set_subconto_value('hr.department', 'subconto_department_id')

--- a/l10n_ua_account_subconto_hr/tests/__init__.py
+++ b/l10n_ua_account_subconto_hr/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_department_subconto

--- a/l10n_ua_account_subconto_hr/tests/test_department_subconto.py
+++ b/l10n_ua_account_subconto_hr/tests/test_department_subconto.py
@@ -1,0 +1,71 @@
+"""HR department works as a subconto dimension once the bridge is installed — issue #182."""
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestDepartmentSubconto(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.department = cls.env['hr.department'].create({'name': 'Бухгалтерія'})
+
+        cls.account = cls.env['account.account'].create({
+            'name': 'Test Subconto Account',
+            'code': 'SUBC01',
+            'account_type': 'asset_current',
+            'company_ids': [(4, cls.env.company.id)],
+        })
+        cls.journal = cls.env['account.journal'].create({
+            'name': 'Subconto Misc',
+            'code': 'SBMSC',
+            'type': 'general',
+            'company_id': cls.env.company.id,
+        })
+        cls.move = cls.env['account.move'].create({
+            'move_type': 'entry',
+            'journal_id': cls.journal.id,
+            'line_ids': [
+                (0, 0, {'account_id': cls.account.id, 'debit': 100.0, 'credit': 0.0}),
+                (0, 0, {'account_id': cls.account.id, 'debit': 0.0, 'credit': 100.0}),
+            ],
+        })
+        cls.line = cls.move.line_ids[0]
+
+    def test_subconto_type_exists(self):
+        """The bridge ships the l10n_ua.subconto.type record the base module lacked."""
+        subconto_type = self.env.ref(
+            'l10n_ua_account_subconto_hr.subconto_type_department')
+        self.assertEqual(subconto_type.model_name, 'hr.department')
+
+    def test_quick_fields_map_includes_department(self):
+        """The base map is extended, not replaced."""
+        mapping = self.env['account.move.line']._subconto_quick_fields_map()
+        self.assertEqual(mapping.get('hr.department'), 'subconto_department_id')
+        self.assertEqual(mapping.get('res.partner'), 'subconto_partner_id')
+        self.assertEqual(mapping.get('product.product'), 'subconto_product_id')
+
+    def test_writing_quick_field_creates_subconto_value(self):
+        """The #182 regression: the inverse silently did nothing (no subconto type)."""
+        self.line.subconto_department_id = self.department
+
+        subconto = self.line.subconto_ids.filtered(
+            lambda s: s.res_model == 'hr.department')
+        self.assertTrue(subconto, 'Writing the quick field must create a subconto value')
+        self.assertEqual(subconto.res_id, self.department.id)
+
+    def test_quick_field_recomputes_from_subconto_value(self):
+        self.line.subconto_department_id = self.department
+        self.line.invalidate_recordset(['subconto_department_id'])
+        self.assertEqual(self.line.subconto_department_id, self.department)
+
+    def test_other_quick_fields_still_work(self):
+        """Extending the map must not break the fields the base module owns."""
+        partner = self.env['res.partner'].create({'name': 'Субконто Контрагент'})
+        self.line.subconto_partner_id = partner
+
+        subconto = self.line.subconto_ids.filtered(
+            lambda s: s.res_model == 'res.partner')
+        self.assertTrue(subconto)
+        self.assertEqual(self.line.subconto_partner_id, partner)

--- a/l10n_ua_account_subconto_hr/views/l10n_ua_subconto_views.xml
+++ b/l10n_ua_account_subconto_hr/views/l10n_ua_subconto_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_move_line_form_subconto_hr" model="ir.ui.view">
+        <field name="name">account.move.line.form.subconto.hr</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="l10n_ua_account_base.view_move_line_form_subconto"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='subconto_quick_fields']" position="inside">
+                <field name="subconto_department_id"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Closes #182.

## Проблема

`l10n_ua_account_base` — фундамент для **13 модулів** — оголошував Many2one на `hr.department`, маючи в `depends` лише `account` і `l10n_ua`. Модуль не встановлювався сам по собі:

```
AssertionError: Field account.move.line.subconto_department_id with unknown comodel_name 'hr.department'
```

Не спливало це лише тому, що `l10n_ua_accounting` тягне `hr`, і база завжди ставилась транзитивно разом із ним. Будь-який ланцюжок без HR ламався — саме на це я натрапив, працюючи над #177.

До того ж поле було **мертвим**: у даних немає типу субконто для `hr.department`, тож `_set_subconto_value` виходив на першому рядку (`if not subconto_type: return`). Запис у поле не робив нічого, compute ніколи його не заповнював. Поле не працювало ні для кого — але ламало інсталяцію й нав'язувало HR-застосунок усьому обліковому дереву.

## Рішення

Додати `'hr'` у `depends` лише закріпило б протікання шарів. Натомість механізм субконто зроблено по-справжньому generic: замість гілок `if res_model == '...'` у compute тепер мапа, яку модулі-мости розширюють.

```python
def _subconto_quick_fields_map(self):
    return {
        'res.partner': 'subconto_partner_id',
        'product.product': 'subconto_product_id',
    }
```

Так велить і коментар у самих даних модуля: *"Additional types for hr, stock, etc. should be created when those modules are installed"* — задум був правильний, його просто не довели.

Новий міст **`l10n_ua_account_subconto_hr`** (`depends: l10n_ua_account_base, hr`) повертає quick-поле, розширює мапу й привозить відсутній `l10n_ua.subconto.type` для `hr.department` — тобто функція **вперше реально працює**. `auto_install=True`, тож наявні бази з `hr` нічого не втрачають.

Група quick-полів у view отримала `name="subconto_quick_fields"`, щоб міст чіплявся xpath'ом по імені — портативно між community та enterprise.

## Перевірено на живих базах

- `l10n_ua_account_base` ставиться на чистій базі **без** `hr`: exit 0, `hr` лишається `uninstalled`, колонки `subconto_department_id` немає, типи субконто = `PARTNER, BANK, ACCOUNT, JOURNAL`.
- Подальше встановлення `hr` у ту саму базу автоматично піднімає міст (`installed`), додає колонку й тип `DEPARTMENT`.
- Усі **13 залежних модулів** встановлюються разом без помилок.
- Жодного посилання на `subconto_department_id` поза мостом не лишилось.

## Тести

Нові, 5 — прогнані разом із повним набором `l10n_ua_accounting`:

- тип субконто існує;
- мапа **розширена, а не замінена** (partner і product на місці);
- запис у quick-поле створює значення субконто — саме те, що раніше мовчки не працювало;
- compute читає значення назад;
- quick-поля partner/product базового модуля не зламані.

## Примітка

У прогоні `l10n_ua_accounting` лишаються дві помилки `TestCashAnalytic` — це #179, виправлений окремо в #180. Ця гілка відгалужена від `19.0` і їх не містить; конфліктів між PR немає.

🤖 Generated with [Claude Code](https://claude.com/claude-code)